### PR TITLE
[CA 873] migrate from OpenApiGenerator to Swagger-Codegen for janitor service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id 'idea'
     id 'com.google.cloud.tools.jib' version '2.4.0'
     id 'org.springframework.boot' version '2.3.1.RELEASE'
-    id 'org.openapi.generator' version '4.3.1'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'com.diffplug.gradle.spotless' version '3.27.2'
     id 'org.hidetake.swagger.generator' version '2.18.2'
@@ -78,6 +77,7 @@ spotless {
 // - define dependencies to include the generated code
 def openapiSourceFile = "${projectDir}/src/main/resources/api/service_openapi.yaml"
 def openapiTargetDir = "${buildDir}/generated"
+def cloudResourceSchemaTargetDor = "${buildDir}/crlSchema"
 
 configurations {
     cloudResourceSchema { transitive = false }
@@ -89,7 +89,7 @@ task unzipCloudResourceSchema(type: Copy) {
     from zipTree(configurations.cloudResourceSchema.singleFile).matching {
         include 'cloud_resources_uid.yaml'
     }
-    into {buildDir}
+    into cloudResourceSchemaTargetDor
 }
 
 swaggerSources {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'org.openapi.generator' version '4.3.1'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'com.diffplug.gradle.spotless' version '3.27.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'bio.terra'
@@ -43,12 +44,9 @@ dependencies {
 
     implementation group: 'bio.terra.cloud-resource-lib', name: 'cloud-resource-schema', version: crlSchemaVersion
 
-    // -- OpenAPI CodeGen dependencies --
-    // TODO: this version of swagger-annotations is old, but the code gen is still relying on it
-    //  There is an open bug tracking the fix: https://github.com/OpenAPITools/openapi-generator/issues/4245
-    implementation group: 'io.swagger', name: 'swagger-annotations', version: '1.6.0'
-    implementation group: 'org.openapitools', name: 'jackson-databind-nullable', version: '0.2.1'
-    // -- --
+    // -- Swagger CodeGen dependencies --
+    swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.20'
+    implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.1.3'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
@@ -91,42 +89,35 @@ task unzipCloudResourceSchema(type: Copy) {
     from zipTree(configurations.cloudResourceSchema.singleFile).matching {
         include 'cloud_resources_uid.yaml'
     }
-    into "$openapiTargetDir"
+    into {buildDir}
 }
 
-openApiGenerate {
-    generatorName = "spring"
-    inputSpec = "${openapiSourceFile}".toString()
-    outputDir = "${openapiTargetDir}".toString()
-    packageName = "${group}"
-    apiPackage = "${group}.generated.controller"
-    modelPackage = "${group}.generated.model"
-    configOptions = [
-            interfaceOnly : "true",
-            useTags : "true",
-            library : "spring-boot",
-            dateLibrary : "java8",
-            generateApiTests : "false",
-            generateApiDocumentation : "false",
-            generateModelTests : "false",
-            generateModelDocumentation : "false",
-    ]
-}
-
-openApiValidate {
-    inputSpec = "${openapiSourceFile}".toString()
+swaggerSources {
+    server {
+        inputFile = file("${openapiSourceFile}")
+        code {
+            language = "spring"
+            outputDir = file("${openapiTargetDir}")
+            components = ['models', 'apis']
+            configFile = file("${projectDir}/src/main/resources/api/swagger-config.json")
+            rawOptions = [
+                    "--api-package", "${this.group}.generated.controller".toString(),
+                    "--model-package", "${this.group}.generated.model".toString(),
+                    "--library", "spring-boot"
+            ]
+        }
+    }
 }
 
 // Note The Open API schema depends on an external library - cloud-resource-schema, so need to unzip it first.
-tasks.openApiGenerate.dependsOn tasks.unzipCloudResourceSchema
+swaggerSources.server.code.dependsOn tasks.unzipCloudResourceSchema
 
 // Note: Spotless deletes the classes OpenApi generates.
 // The order needs to be spotlessApply -> openApiGenerate -> build/test/run
-tasks.openApiGenerate.dependsOn tasks.spotlessApply
-compileJava.dependsOn tasks.openApiGenerate
+swaggerSources.server.code.dependsOn tasks.spotlessApply
+compileJava.dependsOn swaggerSources.server.code
 sourceSets.main.java.srcDir "${openapiTargetDir}/src/main/java"
-ideaModule.dependsOn tasks.openApiGenerate
-
+ideaModule.dependsOn swaggerSources.server.code
 // end of OpenAPI Server Generation
 
 test {
@@ -142,3 +133,4 @@ task unitTest(type: Test) {
     }
     outputs.upToDateWhen { false }
 }
+

--- a/src/main/java/bio/terra/janitor/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/ApplicationConfiguration.java
@@ -1,13 +1,13 @@
 package bio.terra.janitor.app.configuration;
 
 import bio.terra.janitor.app.StartupInitializer;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.apache.commons.dbcp2.PoolableConnection;
 import org.apache.commons.dbcp2.PoolingDataSource;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -34,7 +34,7 @@ public class ApplicationConfiguration {
         .registerModule(new ParameterNamesModule())
         .registerModule(new Jdk8Module())
         .registerModule(new JavaTimeModule())
-        .registerModule(new JsonNullableModule());
+        .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
   }
 
   /**

--- a/src/main/java/bio/terra/janitor/app/controller/JanitorApiController.java
+++ b/src/main/java/bio/terra/janitor/app/controller/JanitorApiController.java
@@ -1,16 +1,39 @@
 package bio.terra.janitor.app.controller;
 
 import bio.terra.generated.controller.JanitorApi;
+import bio.terra.generated.model.CreateResourceRequestBody;
+import bio.terra.generated.model.CreatedResource;
 import bio.terra.generated.model.ResourceDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class JanitorApiController implements JanitorApi {
+  @Override
+  public ResponseEntity<CreatedResource> createResource(@Valid CreateResourceRequestBody body) {
+    // TODO(CA-873): Implement this.
+    return null;
+  }
 
   @Override
   public ResponseEntity<ResourceDescription> getResource(String id) {
     return new ResponseEntity<>(new ResourceDescription().id(id), HttpStatus.OK);
+  }
+
+  /** Required if using Swagger-CodeGen, but actually we don't need this. */
+  @Override
+  public Optional<ObjectMapper> getObjectMapper() {
+    return Optional.empty();
+  }
+
+  /** Required if using Swagger-CodeGen, but actually we don't need this. */
+  @Override
+  public Optional<HttpServletRequest> getRequest() {
+    return Optional.empty();
   }
 }

--- a/src/main/java/bio/terra/janitor/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/janitor/app/controller/UnauthenticatedApiController.java
@@ -4,7 +4,10 @@ import bio.terra.generated.controller.UnauthenticatedApi;
 import bio.terra.generated.model.SystemStatus;
 import bio.terra.generated.model.SystemStatusSystems;
 import bio.terra.janitor.app.configuration.JanitorJdbcConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Connection;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,5 +38,17 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
               .putSystemsItem("postgres", new SystemStatusSystems().ok(false)),
           HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  /** Required if using Swagger-CodeGen, but actually we don't need this. */
+  @Override
+  public Optional<ObjectMapper> getObjectMapper() {
+    return Optional.empty();
+  }
+
+  /** Required if using Swagger-CodeGen, but actually we don't need this. */
+  @Override
+  public Optional<HttpServletRequest> getRequest() {
+    return Optional.empty();
   }
 }

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -34,8 +34,6 @@ paths:
       tags:
         - janitor
       requestBody:
-        description: |
-          Resource UID, time to live, resource labels
         content:
           application/json:
             schema:
@@ -121,8 +119,7 @@ components:
       properties:
         resourceUid:
           # CloudResourceUid is referred from CRL's cloud-resource-schema.
-          description: The UID of the resource in CRL format
-          $ref: '../../../../build/generated/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
+          $ref: '../../../../build/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
         labels:
           description: The labels for the resource
           type: object

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -119,7 +119,7 @@ components:
       properties:
         resourceUid:
           # CloudResourceUid is referred from CRL's cloud-resource-schema.
-          $ref: '../../../../build/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
+          $ref: '../../../../build/crlSchema/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
         labels:
           description: The labels for the resource
           type: object

--- a/src/main/resources/api/swagger-config.json
+++ b/src/main/resources/api/swagger-config.json
@@ -1,0 +1,11 @@
+{
+  "sortParamsByRequiredFlag": false,
+  "interfaceOnly": true,
+  "defaultInterfaces": false,
+  "useTags": true,
+  "dateLibrary": "java8",
+  "generateApiTests": false,
+  "generateApiDocumentation": false,
+  "generateModelTests": false,
+  "generateModelDocumentation": false
+}

--- a/src/test/java/bio/terra/janitor/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/janitor/app/controller/UnauthenticatedApiControllerTest.java
@@ -26,7 +26,7 @@ public class UnauthenticatedApiControllerTest {
   @Test
   public void testStatusOK() throws Exception {
     assertEquals(
-        "{\"ok\":true,\"systems\":{\"postgres\":{\"ok\":true,\"messages\":null}}}",
+        "{\"ok\":true,\"systems\":{\"postgres\":{\"ok\":true}}}",
         this.mvc
             .perform(get("/status"))
             .andExpect(status().isOk())


### PR DESCRIPTION
Things has changed:

- Api Controller needs to override two new method getObjectMapper and getRequest which are not needed by us. So return empty for now.
- Not so many nulls -> in our case, there will be no null get setted if we don't put value in it(see UnauthenticatedApiControllerTest.java)
- Swagger codegen seems deleted the entire target dir first. So need to move the unziped cloud_resource_uid.yaml to another directory. 
- Minor syntax change in service_api yaml file. 