### PR TITLE
[PF-29] fix a typo to enable the scheduler

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ db.stairway.uri=jdbc:postgresql://127.0.0.1:5432/${STAIRWAY_DATABASE_NAME}
 db.stairway.username=${STAIRWAY_DATABASE_USER}
 db.stairway.password=${STAIRWAY_DATABASE_USER_PASSWORD}
 # TODO(PF-35): Only enable scheduling for the primary Janitor instance.
-janitor.primary.schedulingEnabled=true
+janitor.primary.schedulerEnabled=true
 stairway.maxParallelFlights=40
 stairway.migrateUpgrade=true
 stairway.forceCleanStart=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -15,4 +15,4 @@ stairway.migrateUpgrade=true
 stairway.forceCleanStart=true
 stairway.quietDownTimeout=20s
 stairway.terminateTimeout=5s
-pubsub.track-resource.pubsubEnabled=false
+pubsub.track-resource.enabled=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,7 +9,7 @@ db.stairway.uri=jdbc:postgresql://127.0.0.1:5432/testdb_stairway
 db.stairway.username=dbuser_stairway
 db.stairway.password=dbpwd_stairway
 # Testing is easier if we are not scheduling changes to the database by default.
-janitor.primary.schedulingEnabled=false
+janitor.primary.schedulerEnabled=false
 stairway.maxParallelFlights=40
 stairway.migrateUpgrade=true
 stairway.forceCleanStart=true


### PR DESCRIPTION
https://console.cloud.google.com/logs/viewer?interval=NO_LIMIT&project=terra-kernel-k8s&minLogLevel=0&expandAll=false&timestamp=2020-08-11T17:35:40.572000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22terra-kernel-k8s%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22terra-integration%22%0Aresource.labels.namespace_name%3D%22terra-tools%22%0Alabels.k8s-pod%2Fapp%3D%22terra-crl-janitor%22%0AJanitor%20scheduling&scrollTimestamp=2020-08-10T15:17:43.589415723Z