### PR TITLE
PF-5 Add logic for duplicating resources when they are created

### DIFF
--- a/src/main/java/bio/terra/janitor/db/JanitorDao.java
+++ b/src/main/java/bio/terra/janitor/db/JanitorDao.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -110,26 +109,6 @@ public class JanitorDao {
             .addValue("id", trackedResourceId.uuid());
     return Optional.ofNullable(
         DataAccessUtils.singleResult(jdbcTemplate.query(sql, params, TRACKED_RESOURCE_ROW_MAPPER)));
-  }
-
-  /**
-   * Returns a single resource with an expiration less than or equal to {@code expiredyBy} in the
-   * given state, if there is such a TrackedResource.
-   */
-  @Transactional(propagation = Propagation.SUPPORTS)
-  public Optional<TrackedResource> retrieveExpiredResourceWith(
-      Instant expiredBy, TrackedResourceState state) {
-    String sql =
-        "SELECT id, resource_uid, creation, expiration, state FROM tracked_resource "
-            + "WHERE state = :state and expiration <= :expiration LIMIT 1";
-    return Optional.ofNullable(
-        DataAccessUtils.singleResult(
-            jdbcTemplate.query(
-                sql,
-                new MapSqlParameterSource()
-                    .addValue("state", state.toString())
-                    .addValue("expiration", expiredBy.atOffset(ZoneOffset.UTC)),
-                TRACKED_RESOURCE_ROW_MAPPER)));
   }
 
   /** Returns the tracked reosurces matching the {@code filter}. */

--- a/src/main/java/bio/terra/janitor/db/JanitorDao.java
+++ b/src/main/java/bio/terra/janitor/db/JanitorDao.java
@@ -131,42 +131,48 @@ public class JanitorDao {
                     .addValue("expiration", expiredBy.atOffset(ZoneOffset.UTC)),
                 TRACKED_RESOURCE_ROW_MAPPER)));
   }
-  
+
   /** Returns the tracked reosurces matching the {@code filter}. */
   @Transactional(propagation = Propagation.SUPPORTS)
   public List<TrackedResource> retrieveResourcesMatching(TrackedResourceFilter filter) {
+    StringBuilder sql =
+        new StringBuilder(
+            "SELECT id, resource_uid, creation, expiration, state FROM tracked_resource ");
     MapSqlParameterSource params = new MapSqlParameterSource();
-    String whereClause = toSqlWhereClause(filter, params);
-    String sql =
-    "SELECT id, resource_uid, creation, expiration, state FROM tracked_resource WHERE " + whereClause +";";
-    return jdbcTemplate.query(sql, params, TRACKED_RESOURCE_ROW_MAPPER);
-  }
-
-  /**
-   * Returns the tracked resource with the {@link CloudResourceUid} and not in one of the {@code
-   * forbiddenStates}.
-   *
-   * @param cloudResourceUid What CloudResourceUid to retrieve.
-   * @param forbidddenStates What {@link TrackedResourceState} to retrieved resources cannot have.
-   */
-  @Transactional(propagation = Propagation.SUPPORTS)
-  public List<TrackedResource> retrieveResourcesMatching(
-      CloudResourceUid cloudResourceUid, Set<TrackedResourceState> forbidddenStates) {
-    String statesWhereSql = "";
-    if (!forbidddenStates.isEmpty()) {
-      statesWhereSql = " AND state NOT IN(:forbidden_states) ";
+    List<String> whereClauses = new ArrayList<>();
+    if (!filter.allowedStates().isEmpty()) {
+      whereClauses.add("state IN(:filter_allowed_states)");
+      params.addValue(
+          "filter_allowed_states",
+          filter.allowedStates().stream()
+              .map(TrackedResourceState::toString)
+              .collect(Collectors.toList()));
     }
-    String sql =
-        "SELECT id, resource_uid, creation, expiration, state FROM tracked_resource "
-            + "WHERE resource_uid = :cloud_resource_uid::jsonb"
-            + statesWhereSql
-            + ";";
-    return jdbcTemplate.query(
-        sql,
-        new MapSqlParameterSource()
-            .addValue("cloud_resource_uid", serialize(cloudResourceUid))
-            .addValue("forbidden_states", forbidddenStates),
-        TRACKED_RESOURCE_ROW_MAPPER);
+    if (!filter.forbiddenStates().isEmpty()) {
+      whereClauses.add("state NOT IN(:filter_forbidden_states)");
+      params.addValue(
+          "filter_forbidden_states",
+          filter.forbiddenStates().stream()
+              .map(TrackedResourceState::toString)
+              .collect(Collectors.toList()));
+    }
+    if (filter.cloudResourceUid().isPresent()) {
+      whereClauses.add("resource_uid = :filter_cloud_resource_uid::jsonb");
+      params.addValue("filter_cloud_resource_uid", serialize(filter.cloudResourceUid().get()));
+    }
+    if (filter.expiredBy().isPresent()) {
+      whereClauses.add("expiration <= :filters_expired_by");
+      params.addValue("filters_expired_by", filter.expiredBy().get().atOffset(ZoneOffset.UTC));
+    }
+    if (!whereClauses.isEmpty()) {
+      sql.append(whereClauses.stream().collect(Collectors.joining(" AND ", " WHERE ", "")));
+    }
+    if (filter.limit().isPresent()) {
+      sql = sql.append(" LIMIT :filter_limit ");
+      params.addValue("filter_limit", filter.limit().getAsInt());
+    }
+    sql.append(";");
+    return jdbcTemplate.query(sql.toString(), params, TRACKED_RESOURCE_ROW_MAPPER);
   }
 
   /** Return the resource and flight associated with the {@code flightId}, if they exist. */
@@ -375,31 +381,6 @@ public class JanitorDao {
           .map(TrackedResourceAndLabels.Builder::build)
           .collect(Collectors.toList());
     }
-  }
-
-  /** Returns a SQL where clause for the filters, populating the {@code} params with the corresponding values. */
-  private static String toSqlWhereClause(TrackedResourceFilter filter, MapSqlParameterSource params) {
-    if (filter.equals(TrackedResourceFilter.builder().build())) {
-      return "TRUE";
-    }
-    List<String> clauses = new ArrayList<>();
-    if (!filter.allowedStates().isEmpty()) {
-      clauses.add("state IN(:filter_allowed_states)");
-      params.addValue("filter_allowed_states", filter.allowedStates());
-    }
-    if (!filter.forbiddenStates().isEmpty()) {
-      clauses.add("state NOT IN(:filter_forbidden_states");
-      params.addValue("filter_forbidden_states", filter.forbiddenStates());
-    }
-    if (filter.cloudResourceUid().isPresent()) {
-      clauses.add("resource_uid = :filter_cloud_resource_uid::jsonb");
-      params.addValue("filter_cloud_resource_uid", serialize(filter.cloudResourceUid().get()));
-    }
-    if (filter.expiredBy().isPresent()) {
-      clauses.add("expiration <= :filters_expired_by");
-      params.addValue("filters_expired_by", filter.expiredBy().get());
-    }
-    return clauses.stream().collect(Collectors.joining(" AND ", "(", ")"));
   }
 
   /**

--- a/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
+++ b/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
@@ -5,6 +5,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
 /** A value class for filtering which resources are retrieved. */
@@ -22,11 +23,14 @@ public abstract class TrackedResourceFilter {
   /** If present, only resources with an expiration date less than or equal to this are allowed. */
   public abstract Optional<Instant> expiredBy();
 
+  /** If present, only return up to {@code limit} resources. */
+  public abstract OptionalInt limit();
+
   /** Creates a new builder that allows all resources. */
   public static Builder builder() {
     return new AutoValue_TrackedResourceFilter.Builder()
-            .allowedStates(ImmutableSet.of())
-            .forbiddenStates(ImmutableSet.of());
+        .allowedStates(ImmutableSet.of())
+        .forbiddenStates(ImmutableSet.of());
   }
 
   @AutoValue.Builder
@@ -38,6 +42,8 @@ public abstract class TrackedResourceFilter {
     public abstract Builder cloudResourceUid(CloudResourceUid cloudResourceUid);
 
     public abstract Builder expiredBy(Instant expiredBy);
+
+    public abstract Builder limit(int value);
 
     public abstract TrackedResourceFilter build();
   }

--- a/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
+++ b/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
@@ -2,7 +2,9 @@ package bio.terra.janitor.db;
 
 import bio.terra.generated.model.CloudResourceUid;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -45,6 +47,16 @@ public abstract class TrackedResourceFilter {
 
     public abstract Builder limit(int value);
 
-    public abstract TrackedResourceFilter build();
+    abstract TrackedResourceFilter autoBuild();
+
+    public TrackedResourceFilter build() {
+      TrackedResourceFilter filter = autoBuild();
+      Preconditions.checkArgument(
+          Sets.intersection(filter.allowedStates(), filter.forbiddenStates()).isEmpty(),
+          String.format(
+              "TrackedResourceFilter contains states that are allowed and forbidden simultaneously: %s.",
+              filter));
+      return filter;
+    }
   }
 }

--- a/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
+++ b/src/main/java/bio/terra/janitor/db/TrackedResourceFilter.java
@@ -1,0 +1,44 @@
+package bio.terra.janitor.db;
+
+import bio.terra.generated.model.CloudResourceUid;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+
+/** A value class for filtering which resources are retrieved. */
+@AutoValue
+public abstract class TrackedResourceFilter {
+  /** If not empty, only resources with states within this set are allowed. */
+  public abstract ImmutableSet<TrackedResourceState> allowedStates();
+
+  /** If not empty, only resources with states *not* within this set are allowed. */
+  public abstract ImmutableSet<TrackedResourceState> forbiddenStates();
+
+  /** If present, only resources with a matching CloudResourceUid are allowed. */
+  public abstract Optional<CloudResourceUid> cloudResourceUid();
+
+  /** If present, only resources with an expiration date less than or equal to this are allowed. */
+  public abstract Optional<Instant> expiredBy();
+
+  /** Creates a new builder that allows all resources. */
+  public static Builder builder() {
+    return new AutoValue_TrackedResourceFilter.Builder()
+            .allowedStates(ImmutableSet.of())
+            .forbiddenStates(ImmutableSet.of());
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder allowedStates(Set<TrackedResourceState> allowedStates);
+
+    public abstract Builder forbiddenStates(Set<TrackedResourceState> forbiddenStates);
+
+    public abstract Builder cloudResourceUid(CloudResourceUid cloudResourceUid);
+
+    public abstract Builder expiredBy(Instant expiredBy);
+
+    public abstract TrackedResourceFilter build();
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
@@ -2,37 +2,89 @@ package bio.terra.janitor.service.janitor;
 
 import bio.terra.generated.model.*;
 import bio.terra.janitor.db.*;
+import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
 public class JanitorService {
+  private final Logger logger = LoggerFactory.getLogger(JanitorService.class);
 
   private final JanitorDao janitorDao;
+  private final TransactionTemplate transactionTemplate;
 
   @Autowired
-  public JanitorService(JanitorDao janitorDao) {
+  public JanitorService(JanitorDao janitorDao, TransactionTemplate transactionTemplate) {
     this.janitorDao = janitorDao;
+    this.transactionTemplate = transactionTemplate;
   }
 
   public CreatedResource createResource(CreateResourceRequestBody body) {
+    TrackedResourceId id =
+        transactionTemplate.execute(status -> createResourceAndUpdateDuplicates(body, status));
+    return new CreatedResource().id(id.toString());
+  }
+
+  /**
+   * Create a new {@link TrackedResource} and update other resources with the same {@link
+   * CloudResourceUid} as duplicated as appropriate. Returns the created resources {@link
+   * TrackedResourceId}. This should be done as a part of a single database transaction.
+   */
+  private TrackedResourceId createResourceAndUpdateDuplicates(
+      CreateResourceRequestBody body, TransactionStatus unused) {
+    TrackedResourceId id = TrackedResourceId.create(UUID.randomUUID());
     TrackedResource resource =
         TrackedResource.builder()
-            .trackedResourceId(TrackedResourceId.create(UUID.randomUUID()))
+            .trackedResourceId(id)
             .trackedResourceState(TrackedResourceState.READY)
             .cloudResourceUid(body.getResourceUid())
             .creation(body.getCreation().toInstant())
             .expiration(body.getExpiration().toInstant())
             .build();
-
-    // TODO(yonghao): Solution for handling duplicate CloudResourceUid.
+    List<TrackedResource> duplicateResources =
+        janitorDao.retrieveResourcesMatching(
+            resource.cloudResourceUid(),
+            ImmutableSet.of(TrackedResourceState.DONE, TrackedResourceState.DUPLICATED));
+    if (!duplicateResources.isEmpty()) {
+      if (duplicateResources.size() > 1) {
+        // If all resources are created through this function, they should be duplicated
+        // as new resources come in so that there are not multiple resources that need to
+        // be marked as duplicated at once.
+        logger.error(
+            "There was more than one not DONE or DUPLICATE resource with the same CloudResourceUid {}",
+            resource.cloudResourceUid());
+      }
+      Instant lastExpiration =
+          duplicateResources.stream()
+              .map(TrackedResource::expiration)
+              .max(Instant::compareTo)
+              .get();
+      if (resource.expiration().isAfter(lastExpiration)) {
+        // The new resource expires after existing resources. The other resources are now
+        // duplicates of the new resource.
+        for (TrackedResource duplicateResource : duplicateResources) {
+          janitorDao.updateResourceState(
+              duplicateResource.trackedResourceId(), TrackedResourceState.DUPLICATED);
+        }
+      } else {
+        // There is a duplicating resource with a later or equal expiration time. The new
+        // resource is duplicated on arrival.
+        resource =
+            resource.toBuilder().trackedResourceState(TrackedResourceState.DUPLICATED).build();
+      }
+    }
     janitorDao.createResource(resource, body.getLabels());
-    return new CreatedResource().id(resource.trackedResourceId().toString());
+    return id;
   }
 
   /** Retrieves the info about a tracked resource if their exists a resource for that id. */

--- a/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
@@ -53,8 +53,11 @@ public class JanitorService {
             .build();
     List<TrackedResource> duplicateResources =
         janitorDao.retrieveResourcesMatching(
-            resource.cloudResourceUid(),
-            ImmutableSet.of(TrackedResourceState.DONE, TrackedResourceState.DUPLICATED));
+            TrackedResourceFilter.builder()
+                .cloudResourceUid(resource.cloudResourceUid())
+                .forbiddenStates(
+                    ImmutableSet.of(TrackedResourceState.DONE, TrackedResourceState.DUPLICATED))
+                .build());
     if (!duplicateResources.isEmpty()) {
       if (duplicateResources.size() > 1) {
         // If all resources are created through this function, they should be duplicated

--- a/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
+++ b/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
@@ -223,27 +223,6 @@ public class JanitorDaoTest {
   }
 
   @Test
-  public void retrieveExpiredResourceWith() {
-    TrackedResource resource =
-        newDefaultResource()
-            .trackedResourceState(TrackedResourceState.READY)
-            .expiration(EXPIRATION)
-            .build();
-    janitorDao.createResource(resource, ImmutableMap.of());
-
-    assertEquals(
-        Optional.of(resource),
-        janitorDao.retrieveExpiredResourceWith(EXPIRATION, TrackedResourceState.READY));
-    assertEquals(
-        Optional.empty(),
-        janitorDao.retrieveExpiredResourceWith(EXPIRATION, TrackedResourceState.CLEANING));
-    assertEquals(
-        Optional.empty(),
-        janitorDao.retrieveExpiredResourceWith(
-            EXPIRATION.minusSeconds(1), TrackedResourceState.READY));
-  }
-
-  @Test
   public void cleanupFlight() {
     TrackedResource resource = newDefaultResource().build();
     janitorDao.createResource(resource, ImmutableMap.of());

--- a/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
+++ b/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
@@ -10,6 +10,7 @@ import bio.terra.janitor.app.Main;
 import bio.terra.janitor.app.configuration.JanitorJdbcConfiguration;
 import bio.terra.janitor.common.ResourceType;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -152,6 +153,73 @@ public class JanitorDaoTest {
         Optional.empty(),
         janitorDao.updateResourceState(
             TrackedResourceId.create(UUID.randomUUID()), TrackedResourceState.READY));
+  }
+
+  @Test
+  public void retrieveResourcesMatching() {
+    TrackedResource readyResource =
+        newDefaultResource()
+            .trackedResourceState(TrackedResourceState.READY)
+            .expiration(EXPIRATION)
+            .build();
+    TrackedResource errorResource =
+        newDefaultResource()
+            .trackedResourceState(TrackedResourceState.ERROR)
+            .expiration(EXPIRATION)
+            .build();
+    TrackedResource lateExpiredResource =
+        newDefaultResource()
+            .trackedResourceState(TrackedResourceState.ERROR)
+            .expiration(EXPIRATION.plusSeconds(10))
+            .build();
+    janitorDao.createResource(readyResource, ImmutableMap.of());
+    janitorDao.createResource(errorResource, ImmutableMap.of());
+    janitorDao.createResource(lateExpiredResource, ImmutableMap.of());
+
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder()
+                .allowedStates(
+                    ImmutableSet.of(TrackedResourceState.ABANDONED, TrackedResourceState.READY))
+                .build()),
+        Matchers.containsInAnyOrder(readyResource));
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder()
+                .forbiddenStates(ImmutableSet.of(TrackedResourceState.ERROR))
+                .build()),
+        Matchers.containsInAnyOrder(readyResource));
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder()
+                .cloudResourceUid(readyResource.cloudResourceUid())
+                .build()),
+        Matchers.containsInAnyOrder(readyResource));
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder().expiredBy(EXPIRATION).build()),
+        Matchers.containsInAnyOrder(readyResource, errorResource));
+    assertThat(
+        janitorDao.retrieveResourcesMatching(TrackedResourceFilter.builder().limit(1).build()),
+        Matchers.hasSize(1));
+
+    assertThat(
+        janitorDao.retrieveResourcesMatching(TrackedResourceFilter.builder().build()),
+        Matchers.containsInAnyOrder(readyResource, errorResource, lateExpiredResource));
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder()
+                .allowedStates(ImmutableSet.of(TrackedResourceState.CLEANING))
+                .build()),
+        Matchers.empty());
+    assertThat(
+        janitorDao.retrieveResourcesMatching(
+            TrackedResourceFilter.builder()
+                .allowedStates(ImmutableSet.of(TrackedResourceState.READY))
+                .expiredBy(EXPIRATION)
+                .limit(5)
+                .build()),
+        Matchers.containsInAnyOrder(readyResource));
   }
 
   @Test

--- a/src/test/java/bio/terra/janitor/service/janitor/JanitorServiceTest.java
+++ b/src/test/java/bio/terra/janitor/service/janitor/JanitorServiceTest.java
@@ -1,0 +1,83 @@
+package bio.terra.janitor.service.janitor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import bio.terra.generated.model.*;
+import bio.terra.janitor.app.Main;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Tag("unit")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class JanitorServiceTest {
+  private static final OffsetDateTime DEFAULT_TIME = OffsetDateTime.now();
+  @Autowired private JanitorService janitorService;
+
+  /** Returns a map of the resource ids to their TrackedResourceStates as strings. */
+  private static Map<String, String> extractStates(TrackedResourceInfoList resourceList) {
+    return resourceList.getResources().stream()
+        .collect(Collectors.toMap(TrackedResourceInfo::getId, TrackedResourceInfo::getState));
+  }
+
+  @Test
+  public void createResource_Duplicates() {
+    CloudResourceUid resourceUid =
+        new CloudResourceUid().googleBucketUid(new GoogleBucketUid().bucketName("foo"));
+
+    String firstId =
+        janitorService
+            .createResource(
+                new CreateResourceRequestBody()
+                    .resourceUid(resourceUid)
+                    .creation(DEFAULT_TIME)
+                    .expiration(DEFAULT_TIME))
+            .getId();
+    Map<String, String> retrievedStates = extractStates(janitorService.getResources(resourceUid));
+    assertThat(retrievedStates, Matchers.hasEntry(firstId, "READY"));
+    assertThat(retrievedStates, Matchers.aMapWithSize(1));
+
+    // Add a resource with the same CloudResourceUid that expired before the first resource.
+    String secondId =
+        janitorService
+            .createResource(
+                new CreateResourceRequestBody()
+                    .resourceUid(resourceUid)
+                    .creation(DEFAULT_TIME)
+                    .expiration(DEFAULT_TIME.minusMinutes(10)))
+            .getId();
+    retrievedStates = extractStates(janitorService.getResources(resourceUid));
+    assertThat(retrievedStates, Matchers.hasEntry(firstId, "READY"));
+    assertThat(retrievedStates, Matchers.hasEntry(secondId, "DUPLICATED"));
+    assertThat(retrievedStates, Matchers.aMapWithSize(2));
+
+    // Add a resource with the same CloudResourceUid that expired after the first resource.
+    String thirdId =
+        janitorService
+            .createResource(
+                new CreateResourceRequestBody()
+                    .resourceUid(resourceUid)
+                    .creation(DEFAULT_TIME)
+                    .expiration(DEFAULT_TIME.plusMinutes(20)))
+            .getId();
+    retrievedStates = extractStates(janitorService.getResources(resourceUid));
+    assertThat(retrievedStates, Matchers.hasEntry(firstId, "DUPLICATED"));
+    assertThat(retrievedStates, Matchers.hasEntry(secondId, "DUPLICATED"));
+    assertThat(retrievedStates, Matchers.hasEntry(thirdId, "READY"));
+    assertThat(retrievedStates, Matchers.aMapWithSize(3));
+  }
+}


### PR DESCRIPTION
- Use TrackedResourceFilter for retrieving TrackedResources with different filters in JanitorDao.