### PR TITLE
[PF-9] Add admin user authZ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,18 @@ Stop the local postgres:
 ```
 local-dev/run_postgres.sh stop
 ```
+## Authorization
+Janitor uses a list of user email address as administrator user to access its admin endpoint.
+The value can be set in `iam.adminUserList` configuration.
+### For Broad Engineers:
+The file is stored in Vault. 
+To read user list, run:
+```
+docker run -e VAULT_TOKEN=$(cat ~/.vault-token) -it broadinstitute/dsde-toolbox:dev vault read config/terra/crl-janitor/common/iam 
+```
+To request admin access, please contact [mc-terra-janitor-admins](https://github.com/orgs/broadinstitute/teams/mc-terra-janitor-admins) members.
+
+To update user list, run:
+```
+docker run --rm --cap-add IPC_LOCK -e "VAULT_TOKEN=$(cat ~/.vault-token)" -e "VAULT_ADDR=https://clotho.broadinstitute.org:8200" -v $(pwd):/current vault:1.1.0 vault write config/terra/crl-janitor/common/iam admin-users=@/current/{USER_FILE}}
+```

--- a/local-dev/run_local.sh
+++ b/local-dev/run_local.sh
@@ -8,4 +8,5 @@ export STAIRWAY_DATABASE_USER=dbuser_stairway
 export STAIRWAY_DATABASE_USER_PASSWORD=dbpwd_stairway
 export STAIRWAY_DATABASE_NAME=testdb_stairway
 export TRACK_RESOURCE_PUBSUB_ENABLED=false
+export CONFIG_BASED_AUTHZ_ENABLED=false
 ./gradlew bootRun

--- a/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
@@ -18,13 +18,15 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class IamConfiguration {
   private static final Logger logger = LoggerFactory.getLogger(IamConfiguration.class);
 
-  // The file path for admin user list.
+  // The Janitor admin user list.
   private String adminUserList;
+  // Extracted from the adminUserList value. Mutually exclusive with adminUserList.
   private Set<String> adminUsers;
-  private boolean configBasedAuthZEnabled;
+  // If the config based authorization are enabled. If disabled, Janitor will not perform the config
+  // authZ check.
+  private boolean configBasedAuthzEnabled;
 
   public Set<String> getAdminUsers() {
-    logger.warn("Failed to read admin user file from configuration" + adminUserList);
     return adminUsers;
   }
 
@@ -42,17 +44,16 @@ public class IamConfiguration {
                   adminUserList,
                   TypeFactory.defaultInstance().constructCollectionType(Set.class, String.class));
     } catch (IOException e) {
-      logger.warn("Failed to read admin user file from configuration", e);
-      throw new RuntimeException(
-          "Failed to read admin user file from configuration", e);
+      logger.warn("Failed to read admin user list from configuration", e);
+      throw new RuntimeException("Failed to read admin user list from configuration", e);
     }
   }
 
-  public boolean isConfigBasedAuthZEnabled() {
-    return configBasedAuthZEnabled;
+  public boolean isConfigBasedAuthzEnabled() {
+    return configBasedAuthzEnabled;
   }
 
-  public void setConfigBasedAuthZEnabled(boolean configBasedAuthZEnabled) {
-    this.configBasedAuthZEnabled = configBasedAuthZEnabled;
+  public void setConfigBasedAuthzEnabled(boolean configBasedAuthzEnabled) {
+    this.configBasedAuthzEnabled = configBasedAuthzEnabled;
   }
 }

--- a/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
@@ -1,0 +1,56 @@
+package bio.terra.janitor.app.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Component
+@EnableConfigurationProperties
+@EnableTransactionManagement
+@ConfigurationProperties(prefix = "iam")
+public class IamConfiguration {
+  private static final Logger logger = LoggerFactory.getLogger(IamConfiguration.class);
+
+  // The file path for admin user list.
+  private String adminUserList;
+  private Set<String> adminUsers;
+  private boolean configBasedAuthZEnabled;
+
+  public Set<String> getAdminUsers() {
+    return adminUsers;
+  }
+
+  public void setAdminUserList(String adminUserList) {
+    this.adminUserList = adminUserList;
+    parseAdminUserFromConfig();
+  }
+
+  /** Reads {@code adminUserList} and convert to a {@code Set} */
+  private void parseAdminUserFromConfig() {
+    try {
+      adminUsers =
+          new ObjectMapper()
+              .readValue(
+                  adminUserList,
+                  TypeFactory.defaultInstance().constructCollectionType(Set.class, String.class));
+    } catch (IOException e) {
+      logger.warn("Failed to read admin user file from configuration", e);
+      throw new RuntimeException("Failed to read admin user file from configuration", e);
+    }
+  }
+
+  public boolean isConfigBasedAuthZEnabled() {
+    return configBasedAuthZEnabled;
+  }
+
+  public void setConfigBasedAuthZEnabled(boolean configBasedAuthZEnabled) {
+    this.configBasedAuthZEnabled = configBasedAuthZEnabled;
+  }
+}

--- a/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
@@ -24,6 +24,7 @@ public class IamConfiguration {
   private boolean configBasedAuthZEnabled;
 
   public Set<String> getAdminUsers() {
+    logger.warn("Failed to read admin user file from configuration" + adminUserList);
     return adminUsers;
   }
 
@@ -41,8 +42,9 @@ public class IamConfiguration {
                   adminUserList,
                   TypeFactory.defaultInstance().constructCollectionType(Set.class, String.class));
     } catch (IOException e) {
-      logger.warn("Failed to read admin user file from configuration", e);
-      throw new RuntimeException("Failed to read admin user file from configuration", e);
+      logger.warn("Failed to read admin user file from configuration" + adminUserList, e);
+      throw new RuntimeException(
+          "Failed to read admin user file from configuration" + adminUserList, e);
     }
   }
 

--- a/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/IamConfiguration.java
@@ -42,9 +42,9 @@ public class IamConfiguration {
                   adminUserList,
                   TypeFactory.defaultInstance().constructCollectionType(Set.class, String.class));
     } catch (IOException e) {
-      logger.warn("Failed to read admin user file from configuration" + adminUserList, e);
+      logger.warn("Failed to read admin user file from configuration", e);
       throw new RuntimeException(
-          "Failed to read admin user file from configuration" + adminUserList, e);
+          "Failed to read admin user file from configuration", e);
     }
   }
 

--- a/src/main/java/bio/terra/janitor/app/controller/JanitorApiController.java
+++ b/src/main/java/bio/terra/janitor/app/controller/JanitorApiController.java
@@ -32,34 +32,31 @@ public class JanitorApiController implements JanitorApi {
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
   }
 
-  private AuthenticatedUserRequest getAuthenticatedInfo() {
+  private AuthenticatedUserRequest getAuthenticatedRequest() {
     return authenticatedUserRequestFactory.from(request);
   }
 
   @Override
   public ResponseEntity<TrackedResourceInfo> getResource(String id) {
-    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    Optional<TrackedResourceInfo> resource = janitorService.getResource(id, userReq);
-    if (resource.isPresent()) {
-      return new ResponseEntity<>(resource.get(), HttpStatus.OK);
-    } else {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    }
+    Optional<TrackedResourceInfo> resource =
+        janitorService.getResource(id, getAuthenticatedRequest());
+    return resource
+        .map(trackedResourceInfo -> new ResponseEntity<>(trackedResourceInfo, HttpStatus.OK))
+        .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
   }
 
   @Override
   public ResponseEntity<TrackedResourceInfoList> getResources(
       @NotNull @Valid CloudResourceUid cloudResourceUid) {
-    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
     return new ResponseEntity<>(
-        janitorService.getResources(cloudResourceUid, userReq), HttpStatus.OK);
+        janitorService.getResources(cloudResourceUid, getAuthenticatedRequest()), HttpStatus.OK);
   }
 
   @Override
   public ResponseEntity<CreatedResource> createResource(
       @Valid @RequestBody CreateResourceRequestBody body) {
-    AuthenticatedUserRequest userReq = getAuthenticatedInfo();
-    return new ResponseEntity<>(janitorService.createResource(body, userReq), HttpStatus.OK);
+    return new ResponseEntity<>(
+        janitorService.createResource(body, getAuthenticatedRequest()), HttpStatus.OK);
   }
 
   /** Required if using Swagger-CodeGen, but actually we don't need this. */

--- a/src/main/java/bio/terra/janitor/common/exception/ApiException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/ApiException.java
@@ -1,0 +1,12 @@
+package bio.terra.janitor.common.exception;
+
+/** API Exception caused by internal server error. */
+public class ApiException extends InternalServerErrorException {
+  public ApiException(String message) {
+    super(message);
+  }
+
+  public ApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/bio/terra/janitor/common/exception/InternalServerErrorException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/InternalServerErrorException.java
@@ -1,0 +1,12 @@
+package bio.terra.janitor.common.exception;
+
+/** This exception maps to HttpStatus.INTERNAL_SERVER_ERROR in the GlobalExceptionHandler. */
+public class InternalServerErrorException extends ErrorReportException {
+  public InternalServerErrorException(String message) {
+    super(message);
+  }
+
+  public InternalServerErrorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/bio/terra/janitor/common/exception/UnauthorizedException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/UnauthorizedException.java
@@ -1,0 +1,29 @@
+package bio.terra.janitor.common.exception;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+
+/** Exception caused by authorization error. */
+public class UnauthorizedException extends ErrorReportException {
+  private static final HttpStatus thisStatus = HttpStatus.UNAUTHORIZED;
+
+  public UnauthorizedException(String message) {
+    super(message, null, thisStatus);
+  }
+
+  public UnauthorizedException(String message, Throwable cause) {
+    super(message, cause, null, thisStatus);
+  }
+
+  public UnauthorizedException(Throwable cause) {
+    super(null, cause, null, thisStatus);
+  }
+
+  public UnauthorizedException(String message, List<String> causes) {
+    super(message, causes, thisStatus);
+  }
+
+  public UnauthorizedException(String message, Throwable cause, List<String> causes) {
+    super(message, cause, causes, thisStatus);
+  }
+}

--- a/src/main/java/bio/terra/janitor/common/exception/UnauthorizedException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/UnauthorizedException.java
@@ -1,6 +1,5 @@
 package bio.terra.janitor.common.exception;
 
-import java.util.List;
 import org.springframework.http.HttpStatus;
 
 /** Exception caused by authorization error. */
@@ -9,21 +8,5 @@ public class UnauthorizedException extends ErrorReportException {
 
   public UnauthorizedException(String message) {
     super(message, null, thisStatus);
-  }
-
-  public UnauthorizedException(String message, Throwable cause) {
-    super(message, cause, null, thisStatus);
-  }
-
-  public UnauthorizedException(Throwable cause) {
-    super(null, cause, null, thisStatus);
-  }
-
-  public UnauthorizedException(String message, List<String> causes) {
-    super(message, causes, thisStatus);
-  }
-
-  public UnauthorizedException(String message, Throwable cause, List<String> causes) {
-    super(message, cause, causes, thisStatus);
   }
 }

--- a/src/main/java/bio/terra/janitor/service/iam/AuthHeaderKeys.java
+++ b/src/main/java/bio/terra/janitor/service/iam/AuthHeaderKeys.java
@@ -1,0 +1,19 @@
+package bio.terra.janitor.service.iam;
+
+public enum AuthHeaderKeys {
+  // keys for auth headers
+  OIDC_ACCESS_TOKEN("OIDC_ACCESS_token"),
+  AUTHORIZATION("Authorization"),
+  OIDC_CLAIM_EMAIL("OIDC_CLAIM_email"),
+  OIDC_CLAIM_USER_ID("OIDC_CLAIM_user_id");
+
+  private String keyName;
+
+  AuthHeaderKeys(String keyName) {
+    this.keyName = keyName;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequest.java
@@ -1,24 +1,20 @@
 package bio.terra.janitor.service.iam;
 
-import bio.terra.janitor.common.exception.ApiException;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.Optional;
 import java.util.UUID;
 
+/** Captures the inbound authentication information. */
 public class AuthenticatedUserRequest {
   private String email;
   private String subjectId;
-  private Optional<String> token;
-  private UUID reqId;
+  private UUID requestId;
 
   public AuthenticatedUserRequest() {
-    this.reqId = UUID.randomUUID();
+    this.requestId = UUID.randomUUID();
   }
 
-  public AuthenticatedUserRequest(String email, String subjectId, Optional<String> token) {
+  public AuthenticatedUserRequest(String email, String subjectId) {
     this.email = email;
     this.subjectId = subjectId;
-    this.token = token;
   }
 
   public String getSubjectId() {
@@ -39,29 +35,12 @@ public class AuthenticatedUserRequest {
     return this;
   }
 
-  public Optional<String> getToken() {
-    return token;
-  }
-
-  public AuthenticatedUserRequest token(Optional<String> token) {
-    this.token = token;
-    return this;
-  }
-
-  @JsonIgnore
-  public String getRequiredToken() {
-    if (!token.isPresent()) {
-      throw new ApiException("Token required");
-    }
-    return token.get();
-  }
-
-  public UUID getReqId() {
-    return reqId;
+  public UUID getRequestId() {
+    return requestId;
   }
 
   public AuthenticatedUserRequest reqId(UUID reqId) {
-    this.reqId = reqId;
+    this.requestId = reqId;
     return this;
   }
 }

--- a/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequest.java
+++ b/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequest.java
@@ -1,0 +1,67 @@
+package bio.terra.janitor.service.iam;
+
+import bio.terra.janitor.common.exception.ApiException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Optional;
+import java.util.UUID;
+
+public class AuthenticatedUserRequest {
+  private String email;
+  private String subjectId;
+  private Optional<String> token;
+  private UUID reqId;
+
+  public AuthenticatedUserRequest() {
+    this.reqId = UUID.randomUUID();
+  }
+
+  public AuthenticatedUserRequest(String email, String subjectId, Optional<String> token) {
+    this.email = email;
+    this.subjectId = subjectId;
+    this.token = token;
+  }
+
+  public String getSubjectId() {
+    return subjectId;
+  }
+
+  public AuthenticatedUserRequest subjectId(String subjectId) {
+    this.subjectId = subjectId;
+    return this;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public AuthenticatedUserRequest email(String email) {
+    this.email = email;
+    return this;
+  }
+
+  public Optional<String> getToken() {
+    return token;
+  }
+
+  public AuthenticatedUserRequest token(Optional<String> token) {
+    this.token = token;
+    return this;
+  }
+
+  @JsonIgnore
+  public String getRequiredToken() {
+    if (!token.isPresent()) {
+      throw new ApiException("Token required");
+    }
+    return token.get();
+  }
+
+  public UUID getReqId() {
+    return reqId;
+  }
+
+  public AuthenticatedUserRequest reqId(UUID reqId) {
+    this.reqId = reqId;
+    return this;
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/janitor/service/iam/AuthenticatedUserRequestFactory.java
@@ -1,0 +1,8 @@
+package bio.terra.janitor.service.iam;
+
+import javax.servlet.http.HttpServletRequest;
+
+/** An interface for extracting {@link AuthenticatedUserRequest} from {@link HttpServletRequest}. */
+public interface AuthenticatedUserRequestFactory {
+  AuthenticatedUserRequest from(HttpServletRequest servletRequest);
+}

--- a/src/main/java/bio/terra/janitor/service/iam/IamService.java
+++ b/src/main/java/bio/terra/janitor/service/iam/IamService.java
@@ -1,0 +1,30 @@
+package bio.terra.janitor.service.iam;
+
+import bio.terra.janitor.app.configuration.IamConfiguration;
+import bio.terra.janitor.common.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * IAM Service which handles authorization. Currently, Janitor uses a simple user email allow list
+ * to check user permission.
+ *
+ * <p>TODO(PF-81): Switch to use SAM when GKE SAM is ready to use.
+ */
+@Component
+public class IamService {
+  private final IamConfiguration iamConfiguration;
+
+  @Autowired
+  public IamService(IamConfiguration iamConfiguration) {
+    this.iamConfiguration = iamConfiguration;
+  }
+
+  /** Check if user is an administrator. Throws {@link UnauthorizedException} if not. */
+  public void isAdminUser(AuthenticatedUserRequest userReq) {
+    boolean isAdmin = iamConfiguration.getAdminUsers().contains(userReq.getEmail());
+    if (iamConfiguration.isConfigBasedAuthZEnabled() && !isAdmin)
+      throw new UnauthorizedException(
+          "User " + userReq.getEmail() + " is not Janitor's administrator.");
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/iam/IamService.java
+++ b/src/main/java/bio/terra/janitor/service/iam/IamService.java
@@ -21,13 +21,14 @@ public class IamService {
   }
 
   /** Check if user is an administrator. Throws {@link UnauthorizedException} if not. */
-  public void isAdminUser(AuthenticatedUserRequest userReq) {
-    if (iamConfiguration.isConfigBasedAuthZEnabled()) {
+  public void requireAdminUser(AuthenticatedUserRequest userReq) {
+    if (!iamConfiguration.isConfigBasedAuthzEnabled()) {
       return;
     }
     boolean isAdmin = iamConfiguration.getAdminUsers().contains(userReq.getEmail());
-    if (!isAdmin)
+    if (!isAdmin) {
       throw new UnauthorizedException(
           "User " + userReq.getEmail() + " is not Janitor's administrator.");
+    }
   }
 }

--- a/src/main/java/bio/terra/janitor/service/iam/IamService.java
+++ b/src/main/java/bio/terra/janitor/service/iam/IamService.java
@@ -22,8 +22,11 @@ public class IamService {
 
   /** Check if user is an administrator. Throws {@link UnauthorizedException} if not. */
   public void isAdminUser(AuthenticatedUserRequest userReq) {
+    if (iamConfiguration.isConfigBasedAuthZEnabled()) {
+      return;
+    }
     boolean isAdmin = iamConfiguration.getAdminUsers().contains(userReq.getEmail());
-    if (iamConfiguration.isConfigBasedAuthZEnabled() && !isAdmin)
+    if (!isAdmin)
       throw new UnauthorizedException(
           "User " + userReq.getEmail() + " is not Janitor's administrator.");
   }

--- a/src/main/java/bio/terra/janitor/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/janitor/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -1,0 +1,30 @@
+package bio.terra.janitor.service.iam;
+
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of {link AuthenticatedUserRequestFactory} when HTTP requests enter from Apache
+ * Proxy. In this scenario, Janitor service is deployed behind Apache Proxy, and Apache Proxy
+ */
+@Component
+public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
+
+  /** Method to build an AuthenticatedUserRequest from data available to the controller. */
+  public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
+    String token =
+        Optional.ofNullable(servletRequest.getHeader(AuthHeaderKeys.OIDC_ACCESS_TOKEN.getKeyName()))
+            .orElseGet(
+                () -> {
+                  String authHeader =
+                      servletRequest.getHeader(AuthHeaderKeys.AUTHORIZATION.getKeyName());
+                  return StringUtils.substring(authHeader, "Bearer:".length());
+                });
+    return new AuthenticatedUserRequest()
+        .email(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_EMAIL.getKeyName()))
+        .subjectId(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_USER_ID.getKeyName()))
+        .token(Optional.ofNullable(token));
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/iam/ProxiedAuthenticatedUserRequestFactory.java
+++ b/src/main/java/bio/terra/janitor/service/iam/ProxiedAuthenticatedUserRequestFactory.java
@@ -7,24 +7,17 @@ import org.springframework.stereotype.Component;
 
 /**
  * Implementation of {link AuthenticatedUserRequestFactory} when HTTP requests enter from Apache
- * Proxy. In this scenario, Janitor service is deployed behind Apache Proxy, and Apache Proxy
+ * Proxy. In this scenario, Janitor service is deployed behind Apache Proxy, and Apache proxy clears
+ * out any inbound values for these headers, so they are guaranteed to contain valid auth
+ * information.
  */
 @Component
 public class ProxiedAuthenticatedUserRequestFactory implements AuthenticatedUserRequestFactory {
 
   /** Method to build an AuthenticatedUserRequest from data available to the controller. */
   public AuthenticatedUserRequest from(HttpServletRequest servletRequest) {
-    String token =
-        Optional.ofNullable(servletRequest.getHeader(AuthHeaderKeys.OIDC_ACCESS_TOKEN.getKeyName()))
-            .orElseGet(
-                () -> {
-                  String authHeader =
-                      servletRequest.getHeader(AuthHeaderKeys.AUTHORIZATION.getKeyName());
-                  return StringUtils.substring(authHeader, "Bearer:".length());
-                });
     return new AuthenticatedUserRequest()
         .email(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_EMAIL.getKeyName()))
-        .subjectId(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_USER_ID.getKeyName()))
-        .token(Optional.ofNullable(token));
+        .subjectId(servletRequest.getHeader(AuthHeaderKeys.OIDC_CLAIM_USER_ID.getKeyName()));
   }
 }

--- a/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
@@ -36,7 +36,7 @@ public class JanitorService {
 
   public CreatedResource createResource(
       CreateResourceRequestBody body, AuthenticatedUserRequest userReq) {
-    iamService.isAdminUser(userReq);
+    iamService.requireAdminUser(userReq);
     return createResourceInternal(body);
   }
 
@@ -104,7 +104,7 @@ public class JanitorService {
 
   /** Retrieves the info about a tracked resource if their exists a resource for that id. */
   public Optional<TrackedResourceInfo> getResource(String id, AuthenticatedUserRequest userReq) {
-    iamService.isAdminUser(userReq);
+    iamService.requireAdminUser(userReq);
     UUID uuid;
     try {
       uuid = UUID.fromString(id);
@@ -121,7 +121,7 @@ public class JanitorService {
   /** Retrieves the resources with the {@link CloudResourceUid}. */
   public TrackedResourceInfoList getResources(
       CloudResourceUid cloudResourceUid, AuthenticatedUserRequest userReq) {
-    iamService.isAdminUser(userReq);
+    iamService.requireAdminUser(userReq);
     List<TrackedResourceAndLabels> resourcesWithLabels =
         janitorDao.retrieveResourcesWith(cloudResourceUid);
     TrackedResourceInfoList resourceList = new TrackedResourceInfoList();

--- a/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/JanitorService.java
@@ -2,6 +2,8 @@ package bio.terra.janitor.service.janitor;
 
 import bio.terra.generated.model.*;
 import bio.terra.janitor.db.*;
+import bio.terra.janitor.service.iam.AuthenticatedUserRequest;
+import bio.terra.janitor.service.iam.IamService;
 import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -22,14 +24,24 @@ public class JanitorService {
 
   private final JanitorDao janitorDao;
   private final TransactionTemplate transactionTemplate;
+  private final IamService iamService;
 
   @Autowired
-  public JanitorService(JanitorDao janitorDao, TransactionTemplate transactionTemplate) {
+  public JanitorService(
+      JanitorDao janitorDao, TransactionTemplate transactionTemplate, IamService iamService) {
     this.janitorDao = janitorDao;
     this.transactionTemplate = transactionTemplate;
+    this.iamService = iamService;
   }
 
-  public CreatedResource createResource(CreateResourceRequestBody body) {
+  public CreatedResource createResource(
+      CreateResourceRequestBody body, AuthenticatedUserRequest userReq) {
+    iamService.isAdminUser(userReq);
+    return createResourceInternal(body);
+  }
+
+  /** Internal method to Create a new {@link TrackedResource} without user credentials. */
+  public CreatedResource createResourceInternal(CreateResourceRequestBody body) {
     TrackedResourceId id =
         transactionTemplate.execute(status -> createResourceAndUpdateDuplicates(body, status));
     return new CreatedResource().id(id.toString());
@@ -91,7 +103,8 @@ public class JanitorService {
   }
 
   /** Retrieves the info about a tracked resource if their exists a resource for that id. */
-  public Optional<TrackedResourceInfo> getResource(String id) {
+  public Optional<TrackedResourceInfo> getResource(String id, AuthenticatedUserRequest userReq) {
+    iamService.isAdminUser(userReq);
     UUID uuid;
     try {
       uuid = UUID.fromString(id);
@@ -106,7 +119,9 @@ public class JanitorService {
   }
 
   /** Retrieves the resources with the {@link CloudResourceUid}. */
-  public TrackedResourceInfoList getResources(CloudResourceUid cloudResourceUid) {
+  public TrackedResourceInfoList getResources(
+      CloudResourceUid cloudResourceUid, AuthenticatedUserRequest userReq) {
+    iamService.isAdminUser(userReq);
     List<TrackedResourceAndLabels> resourcesWithLabels =
         janitorDao.retrieveResourcesWith(cloudResourceUid);
     TrackedResourceInfoList resourceList = new TrackedResourceInfoList();

--- a/src/main/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriber.java
+++ b/src/main/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriber.java
@@ -72,7 +72,7 @@ public class TrackedResourceSubscriber {
         CreateResourceRequestBody body =
             objectMapper.readValue(
                 message.getData().toStringUtf8(), CreateResourceRequestBody.class);
-        janitorService.createResource(body);
+        janitorService.createResourceInternal(body);
         consumer.ack();
       } catch (Exception e) {
         logger.warn("Invalid track resource pubsub message: " + message.toString(), e);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ stairway.terminateTimeout=5s
 pubsub.track-resource.enabled=${TRACK_RESOURCE_PUBSUB_ENABLED}
 pubsub.track-resource.projectId=${TRACK_RESOURCE_PUBSUB_PROJECT_ID}
 pubsub.track-resource.subscription=${TRACK_RESOURCE_PUBSUB_SUBSCRIPTION}
+# TODO(PF-81): Switch to use SAM instead of config file for user authZ.
+iam.configBasedAuthZEnabled=${CONFIG_BASED_AUTHZ_ENABLED}
+iam.adminUserListFilePath=${ADMIN_USER_LIST}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,5 +20,5 @@ pubsub.track-resource.enabled=${TRACK_RESOURCE_PUBSUB_ENABLED}
 pubsub.track-resource.projectId=${TRACK_RESOURCE_PUBSUB_PROJECT_ID}
 pubsub.track-resource.subscription=${TRACK_RESOURCE_PUBSUB_SUBSCRIPTION}
 # TODO(PF-81): Switch to use SAM instead of config file for user authZ.
-iam.configBasedAuthZEnabled=${CONFIG_BASED_AUTHZ_ENABLED}
-iam.adminUserListFilePath=${ADMIN_USER_LIST}
+iam.configBasedAuthzEnabled=${CONFIG_BASED_AUTHZ_ENABLED}
+iam.adminUserList=${ADMIN_USER_LIST}

--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -11,6 +11,7 @@ import bio.terra.janitor.app.Main;
 import bio.terra.janitor.app.configuration.TrackResourcePubsubConfiguration;
 import bio.terra.janitor.db.TrackedResourceState;
 import bio.terra.janitor.integration.common.configuration.TestConfiguration;
+import bio.terra.janitor.service.iam.AuthHeaderKeys;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.cloud.pubsub.v1.Publisher;
@@ -193,7 +194,8 @@ public class TrackResourceIntegrationTest {
         this.mvc
             .perform(
                 get("/api/janitor/v1/resource")
-                    .queryParam("cloudResourceUid", objectMapper.writeValueAsString(resource)))
+                    .queryParam("cloudResourceUid", objectMapper.writeValueAsString(resource))
+                    .header(AuthHeaderKeys.OIDC_CLAIM_EMAIL.getKeyName(), "test1@email.com"))
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk())
             .andReturn()

--- a/src/test/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriberTest.java
+++ b/src/test/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriberTest.java
@@ -6,6 +6,7 @@ import bio.terra.generated.model.*;
 import bio.terra.janitor.app.Main;
 import bio.terra.janitor.common.exception.InvalidMessageException;
 import bio.terra.janitor.db.TrackedResourceState;
+import bio.terra.janitor.service.iam.AuthenticatedUserRequest;
 import bio.terra.janitor.service.janitor.JanitorService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
@@ -33,6 +34,9 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 public class TrackedResourceSubscriberTest {
+  private static final AuthenticatedUserRequest ADMIN_USER =
+      new AuthenticatedUserRequest().email("test1@email.com");
+
   @Autowired
   @Qualifier("objectMapper")
   private ObjectMapper objectMapper;
@@ -68,9 +72,9 @@ public class TrackedResourceSubscriberTest {
         new TrackedResourceSubscriber.ResourceReceiver(objectMapper, janitorService);
 
     resourceReceiver.receiveMessage(PubsubMessage.newBuilder().setData(data).build(), consumer);
-    janitorService.getResources(resource);
+    janitorService.getResources(resource, ADMIN_USER);
 
-    TrackedResourceInfoList resourceInfoList = janitorService.getResources(resource);
+    TrackedResourceInfoList resourceInfoList = janitorService.getResources(resource, ADMIN_USER);
     assertEquals(1, resourceInfoList.getResources().size());
     TrackedResourceInfo trackedResourceInfo = resourceInfoList.getResources().get(0);
     assertEquals(resource, trackedResourceInfo.getResourceUid());

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -17,3 +17,6 @@ stairway.forceCleanStart=true
 stairway.quietDownTimeout=20s
 stairway.terminateTimeout=5s
 pubsub.track-resource.enabled=false
+iam.configBasedAuthZEnabled=true
+iam.adminUserList=["test1@email.com"]
+


### PR DESCRIPTION
The current implementation uses a config which contains list of admin user email address. 