### PR TITLE
Use terra-helmfile's new version update workflow

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -77,5 +77,5 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: broadinstitute/terra-helmfile
-          event-type: version-bump
+          event-type: update-service
           client-payload: '{"service": "crljanitor", "version": "${{ steps.tag.outputs.tag }}"}'


### PR DESCRIPTION
We have a new, more robust workflow for updating service versions in terra-helmfile (uses yq instead of regex matching). This PR configures janitor to use it.