### PR TITLE
PF-59 Add the Cloud Profiler agent to the jib build.

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and push GCR image using Jib
         run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
         env:
-          SERVICE_TAG: ${{ steps.tag.outputs.tag }}
+          SERVICE_VERSION: ${{ steps.tag.outputs.tag }}
       - name: Update Version Mapping
         uses: broadinstitute/repository-dispatch@master
         with:

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -72,6 +72,8 @@ jobs:
         run: chmod +x gradlew
       - name: Build and push GCR image using Jib
         run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
+        env:
+          SERVICE_TAG: ${{ steps.tag.outputs.tag }}
       - name: Update Version Mapping
         uses: broadinstitute/repository-dispatch@master
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'bio.terra'
-version = System.getenv('SERVICE_TAG') != null ? System.getenv('SERVICE_TAG') : '0.0.1-SNAPSHOT'
+version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -7,15 +7,16 @@ buildscript {
 plugins {
     id 'java'
     id 'idea'
-    id 'com.google.cloud.tools.jib' version '2.4.0'
-    id 'org.springframework.boot' version '2.3.1.RELEASE'
-    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'com.google.cloud.tools.jib' version '2.5.0'
     id 'com.diffplug.gradle.spotless' version '3.27.2'
+    id 'de.undercouch.download' version '4.0.0'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'org.springframework.boot' version '2.3.1.RELEASE'
     id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'bio.terra'
-version = '0.0.1-SNAPSHOT'
+version = System.getenv('SERVICE_TAG') != null ? System.getenv('SERVICE_TAG') : '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 repositories {
@@ -80,11 +81,48 @@ java {
     withJavadocJar()
 }
 
+ext {
+    // where to download the Cloud Profiler agent https://cloud.google.com/profiler/docs/profiling-java
+    cloudProfilerAgentUrl = 'https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz'
+
+    // where to place the Cloud Profiler agent in the container
+    cloudProfilerLocation = '/opt/cprof'
+
+    // location for jib extras, including the Java agent
+    jibExtraDirectory = "${buildDir}/jib-agents"
+}
+
+// Download and extract the Cloud Profiler Java Agent
+task downloadProfilerAgent(type: Download) {
+    src cloudProfilerAgentUrl
+    dest "${buildDir}/cprof_java_agent_gce.tar.gz"
+}
+task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
+    from tarTree(downloadProfilerAgent.dest)
+    into "${jibExtraDirectory}/${cloudProfilerLocation}"
+}
+
 jib {
     from {
         image = "adoptopenjdk:11-jre-hotspot"
     }
+    extraDirectories {
+        paths = [file(jibExtraDirectory)]
+    }
+    container {
+        jvmFlags = [
+                '-agentpath:' + cloudProfilerLocation + '/profiler_java_agent.so=' +
+                        '-cprof_service=bio.terra.janitor' +
+                        ',-cprof_service_version=' + version +
+                        ',-cprof_enable_heap_sampling=true' +
+                        ',-logtostderr'
+        ]
+    }
 }
+
+tasks.jib.dependsOn extractProfilerAgent
+tasks.jibDockerBuild.dependsOn extractProfilerAgent
+tasks.jibBuildTar.dependsOn extractProfilerAgent
 
 // Linter
 spotless {


### PR DESCRIPTION
Enable the Cloud Profiler following instructions from https://cloud.google.com/profiler/docs/profiling-java.

1.  Download and extract the cloud profiler agent during jib container creation.
2.  Set cloud profiler jvm flags for configuration.
3.  Modify push github action workflow to pass service version tag as environment variable for jib.