### PR TITLE
[no ticket] Small documentation & GKE updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You may need to use gcloud to provide GCR
 local-dev/setup_gke_deploy.sh <environment>
 ```
 
+where `environment` is your personal environment (e.g. `gjordan`) or an existing Terra env (e.g. `toolsalpha`).
 You can now push to the specified environment by running
 
 ```

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ The provided setup script clones the terra-helm and terra-helmfile git repos,
 and templates in the desired Terra environment/k8s namespace to target.
 If you need to pull changes to either terra-helm or terra-helmfile, rerun this script.
 
-To use this, first ensure Skaffold is installed on your local machine 
-(available at https://skaffold.dev/). 
+To use this, first ensure the following tools are installed on your local machine:
+ * Skaffold (https://skaffold.dev/)
+ * Helm (https://helm.sh/docs/intro/install/)
 
 > Older versions of Skaffold (v1.4.0 and earlier) do not have support for Helm 3 and will fail to deploy your 
 changes. If you're seeing errors like `UPGRADE FAILED: "(Release name)" has no 

--- a/local-dev/setup_gke_deploy.sh
+++ b/local-dev/setup_gke_deploy.sh
@@ -15,8 +15,8 @@ TERRA_HELMFILE_BRANCH=${3:-master}
 # Clone Helm chart and helmfile repos
 rm -rf terra-helm
 rm -rf terra-helmfile
-git clone -b "$TERRA_HELM_BRANCH" --single-branch https://github.com/broadinstitute/terra-helm
-git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch https://github.com/broadinstitute/terra-helmfile
+git clone -b "$TERRA_HELM_BRANCH" --single-branch git@github.com:broadinstitute/terra-helm.git
+git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch git@github.com:broadinstitute/terra-helmfile.git
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml


### PR DESCRIPTION
The alternative git commands allow the repos to be pulled without entering a GitHub password. This worked much better for me – happy to revert if there's a preferred way for me to be setting up my GitHub creds.