### PR TITLE
[PF-103] Add a base class for unit & integration tests to further reduce duplication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 buildscript {
     repositories {
         mavenCentral()
@@ -187,34 +189,40 @@ ideaModule.dependsOn swaggerSources.server.code
 // This is the path to the default Google service account for the janitor service to run as.
 def googleCredentialsFile = "${projectDir}/src/test/resources/rendered/sa-account.json"
 
-test {
-    //  Sets the application Google Credentials.
+tasks.withType(Test) {
     environment = [
             'GOOGLE_APPLICATION_CREDENTIALS': "${googleCredentialsFile}"
     ]
-    useJUnitPlatform()
+    testLogging {
+        events = ["passed", "failed", "skipped"]
+        // Causes the correct line to be reported on an exception.
+        exceptionFormat = TestExceptionFormat.FULL
+        reports {
+            // Write XML file (used by CircleCI, Jenkins, etc) to api/build/test-results/test
+            junitXml.enabled = true
+            // Write human-readable test report to api/build/reports/
+            html.enabled = true
+        }
+    }
+}
+
+test {
+    useJUnitPlatform {
+        includeTags 'unit', 'integration'
+    }
 }
 
 task unitTest(type: Test) {
     useJUnitPlatform {
         includeTags 'unit'
     }
-    testLogging {
-        events = ["passed", "failed", "skipped", "started"]
-    }
-    outputs.upToDateWhen { false }
 }
 
 task integrationTest(type: Test) {
-    // Sets the application Google Credentials.
-    environment = [
-            'GOOGLE_APPLICATION_CREDENTIALS': "${googleCredentialsFile}"
-    ]
     useJUnitPlatform {
         includeTags "integration"
     }
-    testLogging {
-        events = ["passed", "failed", "skipped", "started"]
-    }
+    // Force tests to always be re-run, since integration tests involve communicating with external
+    // resources.
     outputs.upToDateWhen { false }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -198,9 +198,9 @@ tasks.withType(Test) {
         // Causes the correct line to be reported on an exception.
         exceptionFormat = TestExceptionFormat.FULL
         reports {
-            // Write XML file (used by CircleCI, Jenkins, etc) to api/build/test-results/test
+            // Write XML file (used by CircleCI, Jenkins, etc) to build/test-results/*
             junitXml.enabled = true
-            // Write human-readable test report to api/build/reports/
+            // Write human-readable test report to build/reports/tests/*
             html.enabled = true
         }
     }

--- a/src/test/java/bio/terra/janitor/app/common/ResourceTypeVisitorTest.java
+++ b/src/test/java/bio/terra/janitor/app/common/ResourceTypeVisitorTest.java
@@ -5,23 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.generated.model.*;
-import bio.terra.janitor.app.Main;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.ResourceTypeVisitor;
 import bio.terra.janitor.common.exception.InvalidResourceUidException;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
-public class ResourceTypeVisitorTest {
+public class ResourceTypeVisitorTest extends BaseUnitTest {
   private ResourceTypeVisitor visitor = new ResourceTypeVisitor();
 
   @Test

--- a/src/test/java/bio/terra/janitor/common/BaseIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/common/BaseIntegrationTest.java
@@ -1,0 +1,16 @@
+package bio.terra.janitor.common;
+
+import bio.terra.janitor.app.Main;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Tag("integration")
+@ActiveProfiles({"test", "integration"})
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+public class BaseIntegrationTest {}

--- a/src/test/java/bio/terra/janitor/common/BaseUnitTest.java
+++ b/src/test/java/bio/terra/janitor/common/BaseUnitTest.java
@@ -1,0 +1,16 @@
+package bio.terra.janitor.common;
+
+import bio.terra.janitor.app.Main;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Tag("unit")
+@ActiveProfiles({"test", "unit"})
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+public class BaseUnitTest {}

--- a/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
+++ b/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import bio.terra.generated.model.CloudResourceUid;
 import bio.terra.generated.model.GoogleBucketUid;
 import bio.terra.generated.model.GoogleProjectUid;
-import bio.terra.janitor.app.Main;
 import bio.terra.janitor.app.configuration.JanitorJdbcConfiguration;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.ResourceType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -16,27 +16,16 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class JanitorDaoTest {
+public class JanitorDaoTest extends BaseUnitTest {
   private static final Map<String, String> DEFAULT_LABELS =
       ImmutableMap.of("key1", "value1", "key2", "value2");
 

--- a/src/test/java/bio/terra/janitor/db/TrackedResourceIdTest.java
+++ b/src/test/java/bio/terra/janitor/db/TrackedResourceIdTest.java
@@ -2,15 +2,12 @@ package bio.terra.janitor.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import bio.terra.janitor.common.BaseUnitTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.context.ActiveProfiles;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-public class TrackedResourceIdTest {
+public class TrackedResourceIdTest extends BaseUnitTest {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test

--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -12,8 +12,8 @@ import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.cloudres.google.storage.BucketCow;
 import bio.terra.cloudres.google.storage.StorageCow;
 import bio.terra.generated.model.*;
-import bio.terra.janitor.app.Main;
 import bio.terra.janitor.app.configuration.TrackResourcePubsubConfiguration;
+import bio.terra.janitor.common.BaseIntegrationTest;
 import bio.terra.janitor.db.TrackedResourceState;
 import bio.terra.janitor.integration.common.configuration.TestConfiguration;
 import bio.terra.janitor.service.iam.AuthHeaderKeys;
@@ -38,24 +38,14 @@ import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
-@Tag("integration")
-@ActiveProfiles({"test", "integration"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
-public class TrackResourceIntegrationTest {
+public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   @Autowired private TrackResourcePubsubConfiguration trackResourcePubsubConfiguration;
   @Autowired private TestConfiguration testConfiguration;
   @Autowired private MockMvc mvc;

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.generated.model.CloudResourceUid;
 import bio.terra.generated.model.GoogleBucketUid;
-import bio.terra.janitor.app.Main;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.db.*;
 import bio.terra.janitor.service.cleanup.flight.*;
 import bio.terra.janitor.service.stairway.StairwayComponent;
@@ -17,27 +17,16 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class FlightManagerTest {
+public class FlightManagerTest extends BaseUnitTest {
   private static final Instant CREATION = Instant.EPOCH;
   private static final Instant EXPIRATION = CREATION.plusSeconds(60);
 

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
@@ -6,8 +6,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import bio.terra.generated.model.CloudResourceUid;
 import bio.terra.generated.model.GoogleBucketUid;
-import bio.terra.janitor.app.Main;
 import bio.terra.janitor.app.configuration.PrimaryConfiguration;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.db.*;
 import bio.terra.janitor.service.cleanup.flight.FatalStep;
 import bio.terra.janitor.service.stairway.StairwayComponent;
@@ -19,24 +19,14 @@ import java.time.Instant;
 import java.util.UUID;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-public class FlightSchedulerTest {
+public class FlightSchedulerTest extends BaseUnitTest {
 
   // Construct a FlightScheduler manually instead of Autowired for ease of testing.
   private FlightScheduler flightScheduler;

--- a/src/test/java/bio/terra/janitor/service/cleanup/flight/LatchStepTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/flight/LatchStepTest.java
@@ -3,28 +3,17 @@ package bio.terra.janitor.service.cleanup.flight;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bio.terra.janitor.app.Main;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.service.stairway.StairwayComponent;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
-public class LatchStepTest {
+public class LatchStepTest extends BaseUnitTest {
   @Autowired StairwayComponent stairwayComponent;
 
   @Test

--- a/src/test/java/bio/terra/janitor/service/janitor/TrackedResourceServiceTest.java
+++ b/src/test/java/bio/terra/janitor/service/janitor/TrackedResourceServiceTest.java
@@ -4,32 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.generated.model.*;
-import bio.terra.janitor.app.Main;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.NotFoundException;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-public class TrackedResourceServiceTest {
+public class TrackedResourceServiceTest extends BaseUnitTest {
   private static final OffsetDateTime DEFAULT_TIME = OffsetDateTime.now();
   @Autowired private TrackedResourceService trackedResourceService;
 

--- a/src/test/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriberTest.java
+++ b/src/test/java/bio/terra/janitor/service/pubsub/TrackedResourceSubscriberTest.java
@@ -4,7 +4,7 @@ import static bio.terra.janitor.app.configuration.BeanNames.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.generated.model.*;
-import bio.terra.janitor.app.Main;
+import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.exception.InvalidMessageException;
 import bio.terra.janitor.db.TrackedResourceState;
 import bio.terra.janitor.service.janitor.TrackedResourceService;
@@ -17,24 +17,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@Tag("unit")
-@ActiveProfiles({"test", "unit"})
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
 @AutoConfigureMockMvc
-public class TrackedResourceSubscriberTest {
+public class TrackedResourceSubscriberTest extends BaseUnitTest {
   @Autowired
   @Qualifier(OBJECT_MAPPER)
   private ObjectMapper objectMapper;


### PR DESCRIPTION
I also fixed up some of the Gradle config to show stack traces within failed tests. Not strictly related to the base test class, but it's test-related, so I thought it wasn't worth splitting into a separate cleanup PR.