### PR TITLE
PF-57 Temporarily remove shutdown endpoint.

### DIFF
--- a/src/main/java/bio/terra/janitor/app/controller/UnauthenticatedApiController.java
+++ b/src/main/java/bio/terra/janitor/app/controller/UnauthenticatedApiController.java
@@ -54,21 +54,6 @@ public class UnauthenticatedApiController implements UnauthenticatedApi {
     }
   }
 
-  /** The service will shutdown soon. Halt anything we'd rather not interrupt. */
-  @Override
-  public ResponseEntity<Void> shutdownRequest() {
-    try {
-      flightScheduler.shutdown();
-      if (!stairwayComponent.shutdown()) {
-        // Stairway shutdown did not complete. Return an error so the caller knows that.
-        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-      }
-    } catch (InterruptedException ex) {
-      return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
-    }
-    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-  }
-
   /** Required if using Swagger-CodeGen, but actually we don't need this. */
   @Override
   public Optional<ObjectMapper> getObjectMapper() {

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -33,19 +33,7 @@ paths:
           description: Service is broken
           $ref: '#/components/responses/StatusResponse'
 
-  # TODO(PF-57) configure this to only be callable by Kubernetes in production and to be hooked to Pod termination.
-  '/shutdown':
-    get:
-      description: |
-        Signals that this instance will be shutdown soon. Allows graceful termination to leave less
-        recovery work to be done.  In production, this must be configured to only be callable by Kubernetes.
-      operationId: shutdownRequest
-      tags:
-        - unauthenticated
-      responses:
-        204:
-          description: The service was shutdown successfully
-      security: []
+  # TODO(PF-57) Add a shutdown to only be callable by Kubernetes in production and to be hooked to Pod termination.
 
   '/api/janitor/v1/resource':
     post:

--- a/src/test/java/bio/terra/janitor/app/controller/UnauthenticatedApiControllerTest.java
+++ b/src/test/java/bio/terra/janitor/app/controller/UnauthenticatedApiControllerTest.java
@@ -41,11 +41,4 @@ public class UnauthenticatedApiControllerTest {
     assertThat(status.getSystems(), Matchers.hasKey("postgres"));
     assertThat(status.getSystems(), Matchers.hasKey("stairway"));
   }
-
-  @Test
-  public void shutdownMakesStatusNotOk() throws Exception {
-    this.mvc.perform(get("/status")).andExpect(status().isOk());
-    this.mvc.perform(get("/shutdown")).andExpect(status().isNoContent());
-    this.mvc.perform(get("/status")).andExpect(status().is5xxServerError());
-  }
 }


### PR DESCRIPTION
We're removing the shutdown endpoint which puts the service in a terminating state where it will not run Stairway flights. We do not have an easy way at the moment to restrict the endpoint to k8s lifecycle operations only. Until we do, we're removing the endpoint. See PF-57.