### PR TITLE
PF-122 Handle FlightNotFound for "completed" cleanup flights

### DIFF
--- a/src/main/java/bio/terra/janitor/db/CleanupFlightState.java
+++ b/src/main/java/bio/terra/janitor/db/CleanupFlightState.java
@@ -19,4 +19,6 @@ public enum CleanupFlightState {
   // The flight ended in the fatal, non-recoverable state in Stairway. It did not terminate
   // normally.
   FATAL,
+  // We lost the cleanup flight in Stairway. This should not happen.
+  LOST,
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
@@ -277,8 +277,7 @@ class FlightManager {
           break;
         case LOST:
           // We lost the flight in some unexpected way. We pessimistically assume that the resource
-          // was
-          // not cleaned up.
+          // was not cleaned up.
           finalState = TrackedResourceState.ERROR;
           break;
         default:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ janitor:
       password: ${STAIRWAY_DATABASE_USER_PASSWORD}
       uri: jdbc:postgresql://127.0.0.1:5432/${STAIRWAY_DATABASE_NAME}
       username: ${STAIRWAY_DATABASE_USER}
-    force-clean-start: true
+    force-clean-start: false
     max-parallel-flights: 40
     migrate-upgrade: true
     quiet-down-timeout: 20s

--- a/src/test/java/bio/terra/janitor/db/BackwardsCompatibilityTest.java
+++ b/src/test/java/bio/terra/janitor/db/BackwardsCompatibilityTest.java
@@ -41,4 +41,18 @@ public class BackwardsCompatibilityTest extends BaseUnitTest {
     assertEquals(TrackedResourceState.ABANDONED, TrackedResourceState.valueOf("ABANDONED"));
     assertEquals(TrackedResourceState.DUPLICATED, TrackedResourceState.valueOf("DUPLICATED"));
   }
+
+  /**
+   * Change detection test for existing {@link CleanupFlightState }enum values. More values should
+   * be added as the enum expands.
+   */
+  @Test
+  public void cleanupFlightState() {
+    assertEquals(CleanupFlightState.INITIATING, CleanupFlightState.valueOf("INITIATING"));
+    assertEquals(CleanupFlightState.IN_FLIGHT, CleanupFlightState.valueOf("IN_FLIGHT"));
+    assertEquals(CleanupFlightState.FINISHING, CleanupFlightState.valueOf("FINISHING"));
+    assertEquals(CleanupFlightState.FINISHED, CleanupFlightState.valueOf("FINISHED"));
+    assertEquals(CleanupFlightState.FATAL, CleanupFlightState.valueOf("FATAL"));
+    assertEquals(CleanupFlightState.LOST, CleanupFlightState.valueOf("LOST"));
+  }
 }

--- a/src/test/java/bio/terra/janitor/db/ResourceTypeVisitorTest.java
+++ b/src/test/java/bio/terra/janitor/db/ResourceTypeVisitorTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.generated.model.*;
 import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.exception.InvalidResourceUidException;
-import bio.terra.janitor.db.ResourceTypeVisitor;
 import org.junit.jupiter.api.Test;
 
 public class ResourceTypeVisitorTest extends BaseUnitTest {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,3 +20,5 @@ janitor:
       password: dbpwd_stairway
       uri: jdbc:postgresql://127.0.0.1:5432/testdb_stairway
       username: dbuser_stairway
+    force-clean-start: true
+    migrate-upgrade: true


### PR DESCRIPTION
- Handle FlightNotFound while completing flights. Add CleanupFlightState.LOST for this case.
- Add more verbose logging to FlightManager for tracked resource and flight ids.
- Fix config to stop wiping Stairway on start. Keep wiping stairway for tests on start.