### PR TITLE
Add an index for resource_uid.

### DIFF
--- a/local-dev/run_local.sh
+++ b/local-dev/run_local.sh
@@ -3,10 +3,11 @@
 export DATABASE_USER=dbuser
 export DATABASE_USER_PASSWORD=dbpwd
 export DATABASE_NAME=testdb
-export STACKDRIVER_ENABLED=false
+export JANITOR_STACKDRIVER_ENABLED=false
 export STAIRWAY_DATABASE_USER=dbuser_stairway
 export STAIRWAY_DATABASE_USER_PASSWORD=dbpwd_stairway
 export STAIRWAY_DATABASE_NAME=testdb_stairway
 export TRACK_RESOURCE_PUBSUB_ENABLED=false
 export CONFIG_BASED_AUTHZ_ENABLED=false
+export GOOGLE_APPLICATION_CREDENTIALS=rendered/sa-account.json
 ./gradlew bootRun

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -2,4 +2,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <include file="changesets/20200625_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200903_drop_cleanup_log.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20200925_create_resource_uid.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20200925_create_resource_uid.yaml
+++ b/src/main/resources/db/changesets/20200925_create_resource_uid.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: createIndex-resource-uid
+      author: wchamber
+      changes:
+        - createIndex:
+            tableName: tracked_resource
+            indexName: IDX_TR_CLOUD_RESOURCE_ID
+            columns:
+              - column:
+                  name: resource_uid


### PR DESCRIPTION
- Add an index for resource_uid. We do a lot of searches for matching resource_uids for updating resources. Makes sense to have an index, not based on any specific benchmarking.
- Also fix some local-dev start up environment variables.