### PR TITLE
[PF-485] Registering connection pool with JMX leads to leaks when @DirtiesContext is used.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,8 @@ jobs:
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Check Javadoc
+        run: ./gradlew javadoc --scan
       - name: Run unit tests
         id: unit-test
         run: ./gradlew unitTest --scan

--- a/src/main/java/bio/terra/janitor/app/configuration/JdbcConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/JdbcConfiguration.java
@@ -10,15 +10,37 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 /** Base class for accessing JDBC configuration properties. */
 public class JdbcConfiguration {
+  private boolean jmxEnabled = true;
   private String uri;
   private String username;
   private String password;
 
   // Not a property
   private PoolingDataSource<PoolableConnection> dataSource;
+
+  /**
+   * Returns a boolean indicating whether JMX should be enabled when creating connection pools. If
+   * this is enabled, references to connection pools created at context initialization time will be
+   * placed into an MBean scoped for the lifetime of the JVM. This is OK in production, but can be
+   * an issue for tests that use @DirtiesContext and thus repeatedly initialize connection pools, as
+   * these pools will hold active DB connections while held by JMX. Having this configuration allows
+   * us to disable JMX in test environments. See PF-485 for more details.
+   */
+  public boolean isJmxEnabled() {
+    return jmxEnabled;
+  }
+
+  /**
+   * Sets the value for {@link #isJmxEnabled()}. Used by @ConfigurationProperties in extending
+   * classes ({@link JanitorJdbcConfiguration} and {@link StairwayJdbcConfiguration}).
+   */
+  public void setJmxEnabled(boolean jmxEnabled) {
+    this.jmxEnabled = jmxEnabled;
+  }
 
   public String getUri() {
     return uri;
@@ -65,8 +87,11 @@ public class JdbcConfiguration {
     PoolableConnectionFactory poolableConnectionFactory =
         new PoolableConnectionFactory(connectionFactory, null);
 
+    GenericObjectPoolConfig<PoolableConnection> config = new GenericObjectPoolConfig<>();
+    config.setJmxEnabled(isJmxEnabled());
+
     ObjectPool<PoolableConnection> connectionPool =
-        new GenericObjectPool<>(poolableConnectionFactory);
+        new GenericObjectPool<>(poolableConnectionFactory, config);
 
     poolableConnectionFactory.setPool(connectionPool);
 

--- a/src/main/java/bio/terra/janitor/common/exception/InvalidMessageException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/InvalidMessageException.java
@@ -1,7 +1,8 @@
 package bio.terra.janitor.common.exception;
 
 /**
- * Exception when {@link bio.terra.generated.model.CreateResourceRequestBody} message is invalid.
+ * Exception when {@link bio.terra.janitor.generated.model.CreateResourceRequestBody} message is
+ * invalid.
  */
 public class InvalidMessageException extends RuntimeException {
 

--- a/src/main/java/bio/terra/janitor/common/exception/InvalidResourceUidException.java
+++ b/src/main/java/bio/terra/janitor/common/exception/InvalidResourceUidException.java
@@ -1,6 +1,8 @@
 package bio.terra.janitor.common.exception;
 
-/** Exception when {@link bio.terra.generated.model.CloudResourceUid} in request is invalid. */
+/**
+ * Exception when {@link bio.terra.janitor.generated.model.CloudResourceUid} in request is invalid.
+ */
 public class InvalidResourceUidException extends BadRequestException {
 
   public InvalidResourceUidException(String message) {

--- a/src/main/java/bio/terra/janitor/service/stackdriver/StackdriverExporter.java
+++ b/src/main/java/bio/terra/janitor/service/stackdriver/StackdriverExporter.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/** A component for setting up Stackdriver stats & tracing exporting. */
+/** A component for setting up Stackdriver stats and tracing exporting. */
 @Component
 public class StackdriverExporter {
   private final Logger logger = LoggerFactory.getLogger(StackdriverExporter.class);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,6 +7,9 @@ janitor:
     update-db-on-start: true
     uri: jdbc:postgresql://127.0.0.1:5432/testdb
     username: dbuser
+    # See PF-485 and JdbcConfiguration#isJmxEnabled() for more details.  If/when we stop using
+    # @DirtiesContext, this can be removed.
+    jmx-enabled: false
   iam:
     config-based-authz-enabled: true
     # n.b. this list is stored as a JSON string and parsed by the application. The surrounding
@@ -20,5 +23,8 @@ janitor:
       password: dbpwd_stairway
       uri: jdbc:postgresql://127.0.0.1:5432/testdb_stairway
       username: dbuser_stairway
+      # See PF-485 and JdbcConfiguration#isJmxEnabled() for more details.  If/when we stop using
+      # @DirtiesContext, this can be removed.
+      jmx-enabled: false
     force-clean-start: true
     migrate-upgrade: true


### PR DESCRIPTION
Workaround to prevent connection leak while tests make heavy use of `@DirtiesContext`, see [PF-485] for more detail.

Also includes unrelated fixup of Javadoc errors, and adds javadoc to pre-merge checks (do not squash).

[PF-485]: https://broadworkbench.atlassian.net/browse/PF-485