### PR TITLE
PF-468 publish the janitor client for Java 8 instead of 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.2.0-SNAPSHOT'
+    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.3.0-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_11
     ext {
         artifactGroup = "${group}.janitor"

--- a/terra-resource-janitor-client/build.gradle
+++ b/terra-resource-janitor-client/build.gradle
@@ -6,6 +6,9 @@ plugins {
     id 'org.hidetake.swagger.generator'
 }
 
+// CRL consumes this and is Java 8 to allow other services to use CRL while on Java 8.
+sourceCompatibility = JavaVersion.VERSION_1_8
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
CRL relies on the Janitor client and is still on Java 8. I don't think we had updated the CRL Janitor client since Janitor moved to Java 11.