### PR TITLE
PF-618 Only log errors and fatals from the cloud profiler agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,8 @@ jib {
                         '-cprof_service=bio.terra.janitor' +
                         ',-cprof_service_version=' + version +
                         ',-cprof_enable_heap_sampling=true' +
-                        ',-logtostderr'
+                        ',-logtostderr' +
+                        ',-minloglevel=2'
         ]
     }
 }


### PR DESCRIPTION
Change the logging level for the profiler agent to be less spammy. Ref https://cloud.google.com/profiler/docs/profiling-java#agent_logging