### PR TITLE
PF-194 Succeed when deleting a notebook in delete requested project.

### DIFF
--- a/src/main/java/bio/terra/janitor/app/configuration/ApplicationConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/ApplicationConfiguration.java
@@ -2,7 +2,6 @@ package bio.terra.janitor.app.configuration;
 
 import static bio.terra.janitor.app.configuration.BeanNames.*;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.janitor.app.StartupInitializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,12 +30,6 @@ public class ApplicationConfiguration {
         .registerModule(new JavaTimeModule())
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
-  }
-
-  @Bean(CRL_CLIENT_CONFIG)
-  public ClientConfig clientConfig() {
-    // Janitor only uses CRL Cows to delete resources. Cleanup is not needed.
-    return ClientConfig.Builder.newBuilder().setClient("terra-crl-janitor").build();
   }
 
   /**

--- a/src/main/java/bio/terra/janitor/app/configuration/BeanNames.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/BeanNames.java
@@ -4,8 +4,6 @@ package bio.terra.janitor.app.configuration;
 public class BeanNames {
   private BeanNames() {}
 
-  public static final String JANITOR_DAO = "janitorDao";
-  public static final String CRL_CLIENT_CONFIG = "crlClientConfig";
   public static final String JDBC_TEMPLATE = "jdbcTemplate";
   public static final String OBJECT_MAPPER = "objectMapper";
 }

--- a/src/main/java/bio/terra/janitor/app/configuration/CrlConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/CrlConfiguration.java
@@ -1,0 +1,72 @@
+package bio.terra.janitor.app.configuration;
+
+import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.api.services.common.Defaults;
+import bio.terra.cloudres.google.bigquery.BigQueryCow;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
+import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
+import bio.terra.cloudres.google.storage.StorageCow;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.CloudResourceManagerScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/** Configuration to use Terra Cloud Resource Library (CRL). */
+@Component
+public class CrlConfiguration {
+
+  // Janitor only uses CRL Cows to delete resources. Cleanup is not needed.
+  private final ClientConfig clientConfig =
+      ClientConfig.Builder.newBuilder().setClient("terra-crl-janitor").build();
+
+  @Bean
+  @Lazy
+  public AIPlatformNotebooksCow notebooksCow() throws IOException, GeneralSecurityException {
+    return AIPlatformNotebooksCow.create(clientConfig, GoogleCredentials.getApplicationDefault());
+  }
+
+  @Bean
+  @Lazy
+  public BigQueryCow bigQueryCow() throws IOException, GeneralSecurityException {
+    return BigQueryCow.create(clientConfig, GoogleCredentials.getApplicationDefault());
+  }
+
+  @Bean
+  @Lazy
+  public CloudResourceManagerCow cloudResourceManagerCow()
+      throws IOException, GeneralSecurityException {
+    return new CloudResourceManagerCow(
+        clientConfig,
+        new CloudResourceManager.Builder(
+                Defaults.httpTransport(),
+                Defaults.jsonFactory(),
+                setHttpResourceManagerTimeout(
+                    new HttpCredentialsAdapter(
+                        GoogleCredentials.getApplicationDefault()
+                            .createScoped(CloudResourceManagerScopes.all()))))
+            .setApplicationName(clientConfig.getClientName()));
+  }
+
+  @Bean
+  @Lazy
+  public StorageCow storageCow() {
+    return new StorageCow(clientConfig, StorageOptions.getDefaultInstance());
+  }
+
+  /** Sets longer timeout because ResourceManager operation may take longer than default timeout. */
+  private static HttpRequestInitializer setHttpResourceManagerTimeout(
+      final HttpRequestInitializer requestInitializer) {
+    return httpRequest -> {
+      requestInitializer.initialize(httpRequest);
+      httpRequest.setConnectTimeout(3 * 60000); // 3 minutes connect timeout
+      httpRequest.setReadTimeout(3 * 60000); // 3 minutes read timeout
+    };
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleAiNotebookInstanceCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleAiNotebookInstanceCleanupStep.java
@@ -44,7 +44,8 @@ public class GoogleAiNotebookInstanceCleanupStep extends ResourceCleanupStep {
     try {
       // If the project is already being deleted, trying to delete the instance will 403.
       // But if the project is already being deleted, there's no need to also delete the instance.
-      if (projectDeleteInProgress(instanceName.projectId())) {
+      Project project = resourceManagerCow.projects().get(instanceName.projectId()).execute();
+      if (GoogleUtils.deleteInProgress(project)) {
         logger.info("Project for instance {} already being deleted.", instanceName.formatName());
         return StepResult.getStepResultSuccess();
       }
@@ -82,12 +83,5 @@ public class GoogleAiNotebookInstanceCleanupStep extends ResourceCleanupStep {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
     return StepResult.getStepResultSuccess();
-  }
-
-  private boolean projectDeleteInProgress(String projectId) throws IOException {
-    Project project = resourceManagerCow.projects().get(projectId).execute();
-    return (project == null
-        || project.getLifecycleState().equals("DELETE_REQUESTED")
-        || project.getLifecycleState().equals("DELETE_IN_PROGRESS"));
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryDatasetCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryDatasetCleanupStep.java
@@ -1,6 +1,5 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.janitor.generated.model.CloudResourceUid;
@@ -8,9 +7,7 @@ import bio.terra.janitor.generated.model.GoogleBigQueryDatasetUid;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,17 +15,17 @@ import org.slf4j.LoggerFactory;
 /** Step to cleanup Google BigQuery Dataset resource. */
 public class GoogleBigQueryDatasetCleanupStep extends ResourceCleanupStep {
   private final Logger logger = LoggerFactory.getLogger(GoogleBigQueryDatasetCleanupStep.class);
+  private final BigQueryCow bigQueryCow;
 
-  public GoogleBigQueryDatasetCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
-    super(clientConfig, janitorDao);
+  public GoogleBigQueryDatasetCleanupStep(BigQueryCow bigQueryCow, JanitorDao janitorDao) {
+    super(janitorDao);
+    this.bigQueryCow = bigQueryCow;
   }
 
   @Override
   protected StepResult cleanUp(CloudResourceUid resourceUid) {
     GoogleBigQueryDatasetUid datasetUid = resourceUid.getGoogleBigQueryDatasetUid();
     try {
-      BigQueryCow bigQueryCow =
-          BigQueryCow.create(clientConfig, GoogleCredentials.getApplicationDefault());
       // Because deleteContents is true, this call will delete datasets even if they still have
       // tables present.
       bigQueryCow
@@ -44,7 +41,7 @@ public class GoogleBigQueryDatasetCleanupStep extends ResourceCleanupStep {
       }
       logger.warn("Exception during Dataset Cleanup", e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
-    } catch (IOException | GeneralSecurityException e) {
+    } catch (IOException e) {
       logger.warn("Exception during Dataset Cleanup", e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryTableCleanupFlight.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryTableCleanupFlight.java
@@ -1,9 +1,6 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import static bio.terra.janitor.app.configuration.BeanNames.CRL_CLIENT_CONFIG;
-import static bio.terra.janitor.app.configuration.BeanNames.JANITOR_DAO;
-
-import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -14,15 +11,14 @@ import org.springframework.context.ApplicationContext;
 public class GoogleBigQueryTableCleanupFlight extends Flight {
   public GoogleBigQueryTableCleanupFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
-    JanitorDao janitorDao =
-        ((ApplicationContext) applicationContext).getBean(JANITOR_DAO, JanitorDao.class);
-    ClientConfig clientConfig =
-        ((ApplicationContext) applicationContext).getBean(CRL_CLIENT_CONFIG, ClientConfig.class);
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    JanitorDao janitorDao = appContext.getBean(JanitorDao.class);
+    BigQueryCow bigQueryCow = appContext.getBean(BigQueryCow.class);
     RetryRuleFixedInterval retryRule =
         new RetryRuleFixedInterval(/* intervalSeconds =*/ 180, /* maxCount =*/ 5);
 
     addStep(new InitialCleanupStep(janitorDao));
-    addStep(new GoogleBigQueryTableCleanupStep(clientConfig, janitorDao), retryRule);
+    addStep(new GoogleBigQueryTableCleanupStep(bigQueryCow, janitorDao), retryRule);
     addStep(new FinalCleanupStep(janitorDao));
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryTableCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBigQueryTableCleanupStep.java
@@ -1,6 +1,5 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.janitor.generated.model.CloudResourceUid;
@@ -8,9 +7,7 @@ import bio.terra.janitor.generated.model.GoogleBigQueryTableUid;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,17 +15,17 @@ import org.slf4j.LoggerFactory;
 /** Step to cleanup Google BigQuery Table resource. */
 public class GoogleBigQueryTableCleanupStep extends ResourceCleanupStep {
   private final Logger logger = LoggerFactory.getLogger(GoogleBigQueryTableCleanupStep.class);
+  private final BigQueryCow bigQueryCow;
 
-  public GoogleBigQueryTableCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
-    super(clientConfig, janitorDao);
+  public GoogleBigQueryTableCleanupStep(BigQueryCow bigQueryCow, JanitorDao janitorDao) {
+    super(janitorDao);
+    this.bigQueryCow = bigQueryCow;
   }
 
   @Override
   protected StepResult cleanUp(CloudResourceUid resourceUid) {
     GoogleBigQueryTableUid tableUid = resourceUid.getGoogleBigQueryTableUid();
     try {
-      BigQueryCow bigQueryCow =
-          BigQueryCow.create(clientConfig, GoogleCredentials.getApplicationDefault());
       bigQueryCow
           .tables()
           .delete(tableUid.getProjectId(), tableUid.getDatasetId(), tableUid.getTableId())
@@ -41,7 +38,7 @@ public class GoogleBigQueryTableCleanupStep extends ResourceCleanupStep {
       }
       logger.warn("Exception during BigQuery Table Cleanup", e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
-    } catch (IOException | GeneralSecurityException e) {
+    } catch (IOException e) {
       logger.warn("Exception during BigQuery Table Cleanup", e);
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBlobCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBlobCleanupStep.java
@@ -1,6 +1,5 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.google.storage.StorageCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.janitor.generated.model.CloudResourceUid;
@@ -8,7 +7,6 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,9 +15,9 @@ public class GoogleBlobCleanupStep extends ResourceCleanupStep {
   private final Logger logger = LoggerFactory.getLogger(GoogleBlobCleanupStep.class);
   private final StorageCow storageCow;
 
-  public GoogleBlobCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
-    super(clientConfig, janitorDao);
-    this.storageCow = new StorageCow(clientConfig, StorageOptions.getDefaultInstance());
+  public GoogleBlobCleanupStep(StorageCow storageCow, JanitorDao janitorDao) {
+    super(janitorDao);
+    this.storageCow = storageCow;
   }
 
   @Override

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBucketCleanupFlight.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBucketCleanupFlight.java
@@ -1,9 +1,6 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import static bio.terra.janitor.app.configuration.BeanNames.CRL_CLIENT_CONFIG;
-import static bio.terra.janitor.app.configuration.BeanNames.JANITOR_DAO;
-
-import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.storage.StorageCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -14,15 +11,14 @@ import org.springframework.context.ApplicationContext;
 public class GoogleBucketCleanupFlight extends Flight {
   public GoogleBucketCleanupFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
-    JanitorDao janitorDao =
-        ((ApplicationContext) applicationContext).getBean(JANITOR_DAO, JanitorDao.class);
-    ClientConfig clientConfig =
-        ((ApplicationContext) applicationContext).getBean(CRL_CLIENT_CONFIG, ClientConfig.class);
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    JanitorDao janitorDao = appContext.getBean(JanitorDao.class);
+    StorageCow storageCow = appContext.getBean(StorageCow.class);
     RetryRuleFixedInterval retryRule =
         new RetryRuleFixedInterval(/* intervalSeconds =*/ 180, /* maxCount =*/ 5);
 
     addStep(new InitialCleanupStep(janitorDao));
-    addStep(new GoogleBucketCleanupStep(clientConfig, janitorDao), retryRule);
+    addStep(new GoogleBucketCleanupStep(storageCow, janitorDao), retryRule);
     addStep(new FinalCleanupStep(janitorDao));
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBucketCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleBucketCleanupStep.java
@@ -1,6 +1,5 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.google.storage.BucketCow;
 import bio.terra.cloudres.google.storage.StorageCow;
 import bio.terra.janitor.db.JanitorDao;
@@ -9,7 +8,6 @@ import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -20,9 +18,9 @@ public class GoogleBucketCleanupStep extends ResourceCleanupStep {
   private final Logger logger = LoggerFactory.getLogger(GoogleBucketCleanupStep.class);
   private final StorageCow storageCow;
 
-  public GoogleBucketCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
-    super(clientConfig, janitorDao);
-    this.storageCow = new StorageCow(clientConfig, StorageOptions.getDefaultInstance());
+  public GoogleBucketCleanupStep(StorageCow storageCow, JanitorDao janitorDao) {
+    super(janitorDao);
+    this.storageCow = storageCow;
   }
 
   @Override

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupFlight.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupFlight.java
@@ -1,9 +1,6 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import static bio.terra.janitor.app.configuration.BeanNames.CRL_CLIENT_CONFIG;
-import static bio.terra.janitor.app.configuration.BeanNames.JANITOR_DAO;
-
-import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -14,15 +11,14 @@ import org.springframework.context.ApplicationContext;
 public class GoogleProjectCleanupFlight extends Flight {
   public GoogleProjectCleanupFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
-    JanitorDao janitorDao =
-        ((ApplicationContext) applicationContext).getBean(JANITOR_DAO, JanitorDao.class);
-    ClientConfig clientConfig =
-        ((ApplicationContext) applicationContext).getBean(CRL_CLIENT_CONFIG, ClientConfig.class);
+    ApplicationContext appContext = (ApplicationContext) applicationContext;
+    JanitorDao janitorDao = appContext.getBean(JanitorDao.class);
+    CloudResourceManagerCow resourceManagerCow = appContext.getBean(CloudResourceManagerCow.class);
     RetryRuleFixedInterval retryRule =
         new RetryRuleFixedInterval(/* intervalSeconds =*/ 180, /* maxCount =*/ 5);
 
     addStep(new InitialCleanupStep(janitorDao));
-    addStep(new GoogleProjectCleanupStep(clientConfig, janitorDao), retryRule);
+    addStep(new GoogleProjectCleanupStep(resourceManagerCow, janitorDao), retryRule);
     addStep(new FinalCleanupStep(janitorDao));
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupStep.java
@@ -31,10 +31,7 @@ public class GoogleProjectCleanupStep extends ResourceCleanupStep {
       // deletion, we assume a 403 is for the forbidden case and is an actual error of not being
       // able to clean up with a resource. Therefore, we don't do special handling of the 403 here.
       Project project = resourceManagerCow.projects().get(projectId).execute();
-
-      if (project == null
-          || project.getLifecycleState().equals("DELETE_REQUESTED")
-          || project.getLifecycleState().equals("DELETE_IN_PROGRESS")) {
+      if (GoogleUtils.deleteInProgress(project)) {
         // Skip is project is deleted or being deleted.
         logger.info("Project id: {} is deleted or being deleted", projectId);
         return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleProjectCleanupStep.java
@@ -1,52 +1,28 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import bio.terra.cloudres.common.ClientConfig;
-import bio.terra.cloudres.google.api.services.common.Defaults;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.janitor.generated.model.CloudResourceUid;
 import bio.terra.stairway.StepResult;
 import bio.terra.stairway.StepStatus;
-import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.services.cloudresourcemanager.CloudResourceManager;
-import com.google.api.services.cloudresourcemanager.CloudResourceManagerScopes;
 import com.google.api.services.cloudresourcemanager.model.Project;
-import com.google.auth.http.HttpCredentialsAdapter;
-import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Step to cleanup GCP project resource. */
 public class GoogleProjectCleanupStep extends ResourceCleanupStep {
   private final Logger logger = LoggerFactory.getLogger(GoogleProjectCleanupStep.class);
+  private final CloudResourceManagerCow resourceManagerCow;
 
-  public GoogleProjectCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
-    super(clientConfig, janitorDao);
+  public GoogleProjectCleanupStep(
+      CloudResourceManagerCow resourceManagerCow, JanitorDao janitorDao) {
+    super(janitorDao);
+    this.resourceManagerCow = resourceManagerCow;
   }
 
   @Override
   protected StepResult cleanUp(CloudResourceUid resourceUid) {
-    CloudResourceManagerCow resourceManagerCow;
-
-    try {
-      resourceManagerCow =
-          new CloudResourceManagerCow(
-              clientConfig,
-              new CloudResourceManager.Builder(
-                      Defaults.httpTransport(),
-                      Defaults.jsonFactory(),
-                      setHttpTimeout(
-                          new HttpCredentialsAdapter(
-                              GoogleCredentials.getApplicationDefault()
-                                  .createScoped(CloudResourceManagerScopes.all()))))
-                  .setApplicationName(clientConfig.getClientName()));
-    } catch (GeneralSecurityException | IOException e) {
-      logger.warn("Failed to get application default Google Credentials", e);
-      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
-    }
-
     String projectId = resourceUid.getGoogleProjectUid().getProjectId();
     try {
       // We cannot distinguish between not having access to a project and the project no longer
@@ -71,15 +47,5 @@ public class GoogleProjectCleanupStep extends ResourceCleanupStep {
       // Catch all exceptions from GOOGLE and consider this retryable error.
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
-  }
-
-  /** Sets longer timeout because ResourceManager operation may take longer than default timeout. */
-  private static HttpRequestInitializer setHttpTimeout(
-      final HttpRequestInitializer requestInitializer) {
-    return httpRequest -> {
-      requestInitializer.initialize(httpRequest);
-      httpRequest.setConnectTimeout(3 * 60000); // 3 minutes connect timeout
-      httpRequest.setReadTimeout(3 * 60000); // 3 minutes read timeout
-    };
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleUtils.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/GoogleUtils.java
@@ -1,0 +1,15 @@
+package bio.terra.janitor.service.cleanup.flight;
+
+import com.google.api.services.cloudresourcemanager.model.Project;
+import java.io.IOException;
+
+/** Utilities for working with Google APIs. */
+public class GoogleUtils {
+  private GoogleUtils() {}
+
+  /** Returns whether a project is deleted or in the process of being deleted. */
+  public static boolean deleteInProgress(Project project) throws IOException {
+    return project.getLifecycleState().equals("DELETE_REQUESTED")
+        || project.getLifecycleState().equals("DELETE_IN_PROGRESS");
+  }
+}

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/ResourceCleanupStep.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/ResourceCleanupStep.java
@@ -3,7 +3,6 @@ package bio.terra.janitor.service.cleanup.flight;
 import static bio.terra.janitor.service.cleanup.FlightMapKeys.CLOUD_RESOURCE_UID;
 import static bio.terra.janitor.service.cleanup.FlightMapKeys.TRACKED_RESOURCE_ID;
 
-import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.janitor.db.*;
 import bio.terra.janitor.generated.model.CloudResourceUid;
 import bio.terra.stairway.*;
@@ -15,12 +14,10 @@ import org.slf4j.LoggerFactory;
 public abstract class ResourceCleanupStep implements Step {
   private Logger logger = LoggerFactory.getLogger(ResourceCleanupStep.class);
 
-  private final JanitorDao janitorDao;
-  final ClientConfig clientConfig;
+  protected final JanitorDao janitorDao;
 
-  public ResourceCleanupStep(ClientConfig clientConfig, JanitorDao janitorDao) {
+  public ResourceCleanupStep(JanitorDao janitorDao) {
     this.janitorDao = janitorDao;
-    this.clientConfig = clientConfig;
   }
 
   @Override

--- a/src/main/java/bio/terra/janitor/service/cleanup/flight/UnsupportedCleanupFlight.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/flight/UnsupportedCleanupFlight.java
@@ -1,7 +1,5 @@
 package bio.terra.janitor.service.cleanup.flight;
 
-import static bio.terra.janitor.app.configuration.BeanNames.JANITOR_DAO;
-
 import bio.terra.janitor.db.JanitorDao;
 import bio.terra.stairway.Flight;
 import bio.terra.stairway.FlightMap;
@@ -14,8 +12,7 @@ import org.springframework.context.ApplicationContext;
 public class UnsupportedCleanupFlight extends Flight {
   public UnsupportedCleanupFlight(FlightMap inputParameters, Object applicationContext) {
     super(inputParameters, applicationContext);
-    JanitorDao janitorDao =
-        ((ApplicationContext) applicationContext).getBean(JANITOR_DAO, JanitorDao.class);
+    JanitorDao janitorDao = ((ApplicationContext) applicationContext).getBean(JanitorDao.class);
     addStep(new InitialCleanupStep(janitorDao));
     addStep(new UnsupportedCleanupStep());
     addStep(new FinalCleanupStep(janitorDao));


### PR DESCRIPTION
Handle a special case where the project containing a notebook instance is deleted before the notebook instance is deleted. When this happens, the notebook instance will be deleted.

This does not solve the case when the project was deleted so long ago that it has been completed deleted, but I expect this to still resolve many of the recent and incoming notebook errors.

Refactor Janitor to provide CRL COW beans instead of creating them from ClientConfig each time they're needed.