### PR TITLE
PF-194  Add resource metadata support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.3.0-SNAPSHOT'
+    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.4.0-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_11
     ext {
         artifactGroup = "${group}.janitor"

--- a/src/main/java/bio/terra/janitor/db/JanitorDao.java
+++ b/src/main/java/bio/terra/janitor/db/JanitorDao.java
@@ -425,9 +425,8 @@ public class JanitorDao {
    */
   @VisibleForTesting
   static @Nullable String serialize(ResourceMetadata metadata) {
-    ObjectMapper mapper = SERDES_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     try {
-      return mapper.writeValueAsString(MetadataModelV1.from(metadata));
+      return SERDES_MAPPER.writeValueAsString(MetadataModelV1.from(metadata));
     } catch (JsonProcessingException e) {
       throw new InvalidResourceUidException("Failed to serialize ResourceMetadata");
     }

--- a/src/main/java/bio/terra/janitor/db/ResourceMetadata.java
+++ b/src/main/java/bio/terra/janitor/db/ResourceMetadata.java
@@ -4,9 +4,11 @@ import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
 /**
- * Additional data about a tracked resource. This may be specific to a single resource type and
- * unlike the {@link bio.terra.janitor.generated.model.CloudResourceUid} does not help to uniquely
- * identify a resource.
+ * Additional data about a tracked resource.
+ *
+ * <p>This metadata may be specific to a single resource type and, unlike the {@link
+ * bio.terra.janitor.generated.model.CloudResourceUid}, does not help to uniquely identify a
+ * resource.
  */
 @AutoValue
 public abstract class ResourceMetadata {

--- a/src/main/java/bio/terra/janitor/db/ResourceMetadata.java
+++ b/src/main/java/bio/terra/janitor/db/ResourceMetadata.java
@@ -1,0 +1,36 @@
+package bio.terra.janitor.db;
+
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
+
+/**
+ * Additional data about a tracked resource. This may be specific to a single resource type and
+ * unlike the {@link bio.terra.janitor.generated.model.CloudResourceUid} does not help to uniquely
+ * identify a resource.
+ */
+@AutoValue
+public abstract class ResourceMetadata {
+  /**
+   * The parent resource name of a Google Project resource, e.g. "folders/1234" or
+   * "organizations/1234". This must only be set for Google Project resources, but may be absent.
+   */
+  public abstract Optional<String> googleProjectParent();
+
+  public static Builder builder() {
+    return new AutoValue_ResourceMetadata.Builder();
+  }
+
+  /** Returns an empty {@link ResourceMetadata}. */
+  public static ResourceMetadata none() {
+    return ResourceMetadata.builder().build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder googleProjectParent(Optional<String> googleProjectParent);
+
+    public abstract Builder googleProjectParent(String googleProjectParent);
+
+    public abstract ResourceMetadata build();
+  }
+}

--- a/src/main/java/bio/terra/janitor/db/TrackRequest.java
+++ b/src/main/java/bio/terra/janitor/db/TrackRequest.java
@@ -21,6 +21,9 @@ public abstract class TrackRequest {
   /** The labels to associate with the resource. */
   public abstract ImmutableMap<String, String> labels();
 
+  /** Additional metadata about the resource. */
+  public abstract ResourceMetadata metadata();
+
   public static Builder builder() {
     return new AutoValue_TrackRequest.Builder().labels(ImmutableMap.of());
   }
@@ -35,6 +38,8 @@ public abstract class TrackRequest {
     public abstract Builder expiration(Instant expiration);
 
     public abstract Builder labels(Map<String, String> labels);
+
+    public abstract Builder metadata(ResourceMetadata value);
 
     public abstract TrackRequest build();
   }

--- a/src/main/java/bio/terra/janitor/db/TrackedResource.java
+++ b/src/main/java/bio/terra/janitor/db/TrackedResource.java
@@ -20,6 +20,8 @@ public abstract class TrackedResource {
 
   public abstract Instant expiration();
 
+  public abstract ResourceMetadata metadata();
+
   public static Builder builder() {
     return new AutoValue_TrackedResource.Builder();
   }
@@ -37,6 +39,8 @@ public abstract class TrackedResource {
     public abstract Builder creation(Instant creationTime);
 
     public abstract Builder expiration(Instant expirationTime);
+
+    public abstract Builder metadata(ResourceMetadata value);
 
     public abstract TrackedResource build();
   }

--- a/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** Helper class for converting to and from the request/response model format. */
 public class ModelUtils {
@@ -43,7 +44,10 @@ public class ModelUtils {
   }
 
   private static ResourceMetadata createMetadata(
-      bio.terra.janitor.generated.model.ResourceMetadata model) {
+      @Nullable bio.terra.janitor.generated.model.ResourceMetadata model) {
+    if (model == null) {
+      return ResourceMetadata.none();
+    }
     return ResourceMetadata.builder()
         .googleProjectParent(Optional.ofNullable(model.getGoogleProjectParent()))
         .build();
@@ -54,6 +58,7 @@ public class ModelUtils {
     return new TrackedResourceInfo()
         .id(resource.trackedResourceId().toString())
         .resourceUid(resource.cloudResourceUid())
+        .metadata(convert(resource.metadata()))
         .state(convert(resource.trackedResourceState()))
         .creation(OffsetDateTime.ofInstant(resource.creation(), ZoneOffset.UTC))
         .expiration(OffsetDateTime.ofInstant(resource.expiration(), ZoneOffset.UTC))
@@ -65,6 +70,15 @@ public class ModelUtils {
     Preconditions.checkNotNull(
         converted, String.format("Unable to convert TrackedResourceState %s", state));
     return converted;
+  }
+
+  public static bio.terra.janitor.generated.model.ResourceMetadata convert(
+      ResourceMetadata metadata) {
+    if (metadata.equals(ResourceMetadata.none())) {
+      return null;
+    }
+    return new bio.terra.janitor.generated.model.ResourceMetadata()
+        .googleProjectParent(metadata.googleProjectParent().orElse(null));
   }
 
   public static TrackedResourceState convert(ResourceState state) {

--- a/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
@@ -43,7 +43,7 @@ public class ModelUtils {
         .build();
   }
 
-  private static ResourceMetadata createMetadata(
+  private static @Nullable ResourceMetadata createMetadata(
       @Nullable bio.terra.janitor.generated.model.ResourceMetadata model) {
     if (model == null) {
       return ResourceMetadata.none();

--- a/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/ModelUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.janitor.service.janitor;
 
+import bio.terra.janitor.db.ResourceMetadata;
 import bio.terra.janitor.db.TrackRequest;
 import bio.terra.janitor.db.TrackedResource;
 import bio.terra.janitor.db.TrackedResourceAndLabels;
@@ -13,6 +14,7 @@ import com.google.common.collect.EnumBiMap;
 import com.google.common.collect.ImmutableMap;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 
 /** Helper class for converting to and from the request/response model format. */
 public class ModelUtils {
@@ -36,6 +38,14 @@ public class ModelUtils {
         .creation(body.getCreation().toInstant())
         .expiration(body.getExpiration().toInstant())
         .labels(body.getLabels() == null ? ImmutableMap.of() : body.getLabels())
+        .metadata(createMetadata(body.getResourceMetadata()))
+        .build();
+  }
+
+  private static ResourceMetadata createMetadata(
+      bio.terra.janitor.generated.model.ResourceMetadata model) {
+    return ResourceMetadata.builder()
+        .googleProjectParent(Optional.ofNullable(model.getGoogleProjectParent()))
         .build();
   }
 

--- a/src/main/java/bio/terra/janitor/service/janitor/TrackedResourceService.java
+++ b/src/main/java/bio/terra/janitor/service/janitor/TrackedResourceService.java
@@ -52,6 +52,7 @@ public class TrackedResourceService {
             .cloudResourceUid(trackRequest.cloudResourceUid())
             .creation(trackRequest.creation())
             .expiration(trackRequest.expiration())
+            .metadata(trackRequest.metadata())
             .build();
     List<TrackedResource> duplicateResources =
         janitorDao.retrieveResourcesMatching(

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -218,6 +218,8 @@ components:
         resourceUid:
           # CloudResourceUid is referred from CRL's cloud-resource-schema.
           $ref: '../../../../build/crlSchema/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
+        resourceMetadata:
+          $ref: '#/components/schemas/ResourceMetadata'
         labels:
           description: The labels for the resource
           type: object
@@ -287,6 +289,16 @@ components:
         - ERROR
         - ABANDONED
         - DUPLIATED
+
+    ResourceMetadata:
+      type: object
+      description: Additional information about a resource that does not uniquely identify.
+      properties:
+        googleProjectParent:
+          type: string
+          description: |
+            The parent resource name of a Google Project resource, e.g. "folders/1234" or
+            "organizations/1234". This must only be set for Google Project resources.
 
   responses:
     ErrorResponse:

--- a/src/main/resources/api/service_openapi.yaml
+++ b/src/main/resources/api/service_openapi.yaml
@@ -253,6 +253,8 @@ components:
         resourceUid:
           description: The CloudResourceUid of the tracked resource.
           $ref: '../../../../build/crlSchema/cloud_resources_uid.yaml#/components/schemas/CloudResourceUid'
+        metadata:
+          $ref: '#/components/schemas/ResourceMetadata'
         state:
           description: The state of the tracked resource's cleanup.
           $ref: '#/components/schemas/ResourceState'

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -3,4 +3,5 @@
     <include file="changesets/20200625_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200903_drop_cleanup_log.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20200925_create_resource_uid.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210520_add_metadata.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20210520_add_metadata.yaml
+++ b/src/main/resources/db/changesets/20210520_add_metadata.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-metadata-column
+      author: wchamber
+      changes:
+        - addColumn:
+            tableName: tracked_resource
+            columns:
+              name: metadata
+              type: jsonb
+              constraints:
+                nullable: true

--- a/src/test/java/bio/terra/janitor/app/controller/JanitorApiControllerTest.java
+++ b/src/test/java/bio/terra/janitor/app/controller/JanitorApiControllerTest.java
@@ -46,6 +46,7 @@ public class JanitorApiControllerTest {
   private static final OffsetDateTime CREATION = OffsetDateTime.now(ZoneOffset.UTC);
   private static final OffsetDateTime EXPIRATION =
       OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(10);
+  private static final String PROJECT_PARENT = "folders/1234";
   private static final String CLAIM_EMAIL_KEY = "OIDC_CLAIM_email";
   private static final String CLAIM_SUBJECT_KEY = "OIDC_CLAIM_user_id";
   private static final String CLAIM_TOKEN_KEY = "OIDC_ACCESS_token";
@@ -69,6 +70,7 @@ public class JanitorApiControllerTest {
     CreateResourceRequestBody body =
         new CreateResourceRequestBody()
             .resourceUid(resourceUid)
+            .resourceMetadata(new ResourceMetadata().googleProjectParent(PROJECT_PARENT))
             .creation(CREATION)
             .expiration(EXPIRATION)
             .labels(DEFAULT_LABELS);
@@ -114,6 +116,7 @@ public class JanitorApiControllerTest {
     assertEquals(CREATION, trackedResourceInfo.getCreation());
     assertEquals(EXPIRATION, trackedResourceInfo.getExpiration());
     assertEquals(DEFAULT_LABELS, trackedResourceInfo.getLabels());
+    assertEquals(PROJECT_PARENT, trackedResourceInfo.getMetadata().getGoogleProjectParent());
   }
 
   @Test

--- a/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
+++ b/src/test/java/bio/terra/janitor/db/JanitorDaoTest.java
@@ -50,7 +50,8 @@ public class JanitorDaoTest extends BaseUnitTest {
             new CloudResourceUid()
                 .googleProjectUid(new GoogleProjectUid().projectId(UUID.randomUUID().toString())))
         .creation(CREATION)
-        .expiration(EXPIRATION);
+        .expiration(EXPIRATION)
+        .metadata(ResourceMetadata.none());
   }
 
   @Test
@@ -60,6 +61,24 @@ public class JanitorDaoTest extends BaseUnitTest {
     String serialized = "{\"googleProjectUid\":{\"projectId\":\"my-project\"}}";
     assertEquals(serialized, JanitorDao.serialize(cloudResourceUid));
     assertEquals(cloudResourceUid, JanitorDao.deserialize(serialized));
+  }
+
+  @Test
+  public void serializeResourceMetadata() {
+    ResourceMetadata metadata =
+        ResourceMetadata.builder().googleProjectParent("folders/1234").build();
+    String serialized = "{\"version\":1,\"googleProjectParent\":\"folders/1234\"}";
+    assertEquals(serialized, JanitorDao.serialize(metadata));
+    assertEquals(metadata, JanitorDao.deserializeMetadata(serialized));
+  }
+
+  @Test
+  public void serializeResourceMetadataNone() {
+    ResourceMetadata none = ResourceMetadata.none();
+    String serialized = "{\"version\":1}";
+    assertEquals(serialized, JanitorDao.serialize(none));
+    assertEquals(none, JanitorDao.deserializeMetadata(serialized));
+    assertEquals(none, JanitorDao.deserializeMetadata(null));
   }
 
   @Test
@@ -74,6 +93,7 @@ public class JanitorDaoTest extends BaseUnitTest {
             .cloudResourceUid(cloudResourceUid)
             .creation(CREATION)
             .expiration(EXPIRATION)
+            .metadata(ResourceMetadata.builder().googleProjectParent("folders/1234").build())
             .build();
     janitorDao.createResource(resource, DEFAULT_LABELS);
 

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
@@ -48,6 +48,7 @@ public class FlightManagerTest extends BaseUnitTest {
                 .googleBucketUid(new GoogleBucketUid().bucketName(UUID.randomUUID().toString())))
         .creation(CREATION)
         .expiration(EXPIRATION)
+        .metadata(ResourceMetadata.none())
         .build();
   }
 

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
@@ -72,6 +72,7 @@ public class FlightSchedulerTest extends BaseUnitTest {
             new CloudResourceUid().googleBucketUid(new GoogleBucketUid().bucketName("foo")))
         .creation(expiredBy)
         .expiration(expiredBy)
+        .metadata(ResourceMetadata.none())
         .build();
   }
 

--- a/src/test/java/bio/terra/janitor/service/janitor/TrackedResourceServiceTest.java
+++ b/src/test/java/bio/terra/janitor/service/janitor/TrackedResourceServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import bio.terra.janitor.common.BaseUnitTest;
 import bio.terra.janitor.common.NotFoundException;
 import bio.terra.janitor.db.*;
+import bio.terra.janitor.db.ResourceMetadata;
 import bio.terra.janitor.generated.model.*;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
@@ -53,6 +54,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME)
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
     assertEquals(
@@ -67,6 +69,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME.minusSeconds(10))
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
     assertEquals(
@@ -82,6 +85,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME.plusSeconds(20))
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
     assertEquals(
@@ -105,6 +109,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME)
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
 
@@ -117,6 +122,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME)
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
 
@@ -146,6 +152,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME)
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
     janitorDao.updateResourceState(cleaningId, TrackedResourceState.CLEANING);
@@ -169,6 +176,7 @@ public class TrackedResourceServiceTest extends BaseUnitTest {
                     .cloudResourceUid(resourceUid)
                     .creation(DEFAULT_TIME)
                     .expiration(DEFAULT_TIME)
+                    .metadata(ResourceMetadata.none())
                     .build())
             .trackedResourceId();
     janitorDao.updateResourceState(errorId, TrackedResourceState.ERROR);


### PR DESCRIPTION
Add resource metadata to the client, internal representation, and database to allow adding additional information about a tracked resource that isn't its unique id or a label.
We will initially use this for Google project parents in order to help cleanup of projects that don't exist.