### PR TITLE
[no-ticket] increase the polling timeout for integratoin tests.

### DIFF
--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -483,7 +483,7 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     publisher.publish(PubsubMessage.newBuilder().setData(data).build());
 
     TrackedResourceInfoList resourceInfoList =
-        pollUntilResourceState(request.getResourceUid(), expectedState, Duration.ofSeconds(5), 10);
+        pollUntilResourceState(request.getResourceUid(), expectedState, Duration.ofSeconds(5), 60);
 
     assertEquals(1, resourceInfoList.getResources().size());
     TrackedResourceInfo trackedResourceInfo = resourceInfoList.getResources().get(0);


### PR DESCRIPTION
AI notebook deletion can take a while. Give it 5 minutes before timing out the test