### PR TITLE
DDO-1319 Update local dev workflow for Janitor to use `render`

### DIFF
--- a/local-dev/.gitignore
+++ b/local-dev/.gitignore
@@ -1,9 +1,3 @@
-# Ignore everything in this directory...
-*
-./terra-helmfile/**
-
-# Except...
-!.gitignore
-!local-postgres-init.sql
-!*.sh
-!*.template
+terra-helmfile
+skaffold.yaml
+values.yaml

--- a/local-dev/.gitignore
+++ b/local-dev/.gitignore
@@ -5,6 +5,5 @@
 # Except...
 !.gitignore
 !local-postgres-init.sql
-!README.md
 !*.sh
 !*.template

--- a/local-dev/.gitignore
+++ b/local-dev/.gitignore
@@ -1,0 +1,10 @@
+# Ignore everything in this directory...
+*
+./terra-helmfile/**
+
+# Except...
+!.gitignore
+!local-postgres-init.sql
+!README.md
+!*.sh
+!*.template

--- a/local-dev/setup_gke_deploy.sh
+++ b/local-dev/setup_gke_deploy.sh
@@ -9,18 +9,34 @@ set -e
 # Required input
 ENV=$1
 # Optional input
-TERRA_HELM_BRANCH=${2:-master}
-TERRA_HELMFILE_BRANCH=${3:-master}
+TERRA_HELMFILE_BRANCH=${2:-master}
+GIT_PROTOCOL=${3:-http}
+
+if [ "$GIT_PROTOCOL" = "http" ]; then
+    helmfilegit=https://github.com/broadinstitute/terra-helmfile
+else
+    helmfilegit=git@github.com:broadinstitute/terra-helmfile.git
+fi
 
 # Clone Helm chart and helmfile repos
-rm -rf terra-helm
 rm -rf terra-helmfile
-git clone -b "$TERRA_HELM_BRANCH" --single-branch git@github.com:broadinstitute/terra-helm.git
-git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch git@github.com:broadinstitute/terra-helmfile.git
+git clone -b "$TERRA_HELMFILE_BRANCH" --single-branch "${helmfilegit}"
 
 # Template in environment
 sed "s|ENV|${ENV}|g" skaffold.yaml.template > skaffold.yaml
 sed "s|ENV|${ENV}|g" values.yaml.template > values.yaml
+
+# Render manifests to terra-helmfile/output/ directory.
+#
+# Unfortunately we need to render them all into a single mega-file
+# because Skaffold's `kubectl` deployment does not support
+# recursive globbing like "output/manifests/**/*.yaml"
+mkdir -p ./terra-helmfile/output
+./terra-helmfile/bin/render \
+  -e "${ENV}" \
+  -a crljanitor \
+  --values-file ./values.yaml \
+  --stdout > terra-helmfile/output/manifests.yaml
 
 # That's it! You can now deploy to the k8s cluster by running
 # $ skaffold run

--- a/local-dev/skaffold.yaml.template
+++ b/local-dev/skaffold.yaml.template
@@ -1,5 +1,5 @@
 #This is a Skaffold configuration, which lets developers continuously push new images to their development namespaces.
-apiVersion: skaffold/v2alpha4
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
@@ -7,16 +7,7 @@ build:
     context: ../
     jib: {}
 deploy:
-  helm:
-    releases:
-      - name: crljanitor-ENV
-        namespace: terra-ENV
-        chartPath: terra-helm/charts/crljanitor
-        skipBuildDependencies: true
-        values:
-          image: gcr.io/terra-kernel-k8s/terra-resource-janitor
-        valuesFiles:
-          - terra-helmfile/terra/values/crljanitor.yaml
-          - terra-helmfile/terra/values/crljanitor/personal.yaml
-          - terra-helmfile/terra/values/crljanitor/personal/ENV.yaml
-          - values.yaml
+  kubectl:
+    manifests:
+    - terra-helmfile/output/manifests.yaml
+    defaultNamespace: terra-ENV


### PR DESCRIPTION
DevOps is preparing to make some structural changes to the terra-helmfile repo; this PR updates buffer's Skaffold development workflow to be resilient to the upcoming changes. Changes include:
* Add .gitignore (shamelessly copied from WSM)
* Remove references to terra-helm
* Render manifests using terra-helmfile's `render` tool instead of invoking helm with hardcoded paths to values files
* Use Skaffold's kubectl deployment option to deploy rendered manifests

I have tested these changes by deploying `janitor` to the gmalkov personal environment.