### PR TITLE
[no ticket] bump cloud resource uid version to have Azure changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
             //
             // https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/211
 
-            dependency group: 'bio.terra.cloud-resource-lib', name: 'cloud-resource-schema', version: "0.9.0"
+            dependency group: 'bio.terra.cloud-resource-lib', name: 'cloud-resource-schema', version: "0.10.0"
         }
     }
 

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-bio.terra.cloud-resource-lib:cloud-resource-schema:0.9.0=cloudResourceSchema,compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+bio.terra.cloud-resource-lib:cloud-resource-schema:0.10.0=cloudResourceSchema,compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:common:0.9.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-api-services-common:0.9.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 bio.terra.cloud-resource-lib:google-bigquery:0.11.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PF-866, for cloud resource uid, we need to manually upgrade the version, 
Currently Janitor is broken due to invalid messages.
 