### PR TITLE
[no ticket] Clean test before publish

### DIFF
--- a/terra-resource-janitor-client/publish.sh
+++ b/terra-resource-janitor-client/publish.sh
@@ -8,5 +8,4 @@ export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOL
  vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
 export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
  vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
-../gradlew test
-../gradlew artifactoryPublish
+../gradlew test clean artifactoryPublish


### PR DESCRIPTION
 artifactoryPublis does not publish new packages if there is already a build target (or when there is no change in that build dir)