### PR TITLE
[no ticket] use 0.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.7.0-SNAPSHOT'
+    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.7.1-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_11
     ext['log4j2.version'] = '2.17.0' // until Spring Boot 2.6.2
     ext {

--- a/terra-resource-janitor-client/publish.sh
+++ b/terra-resource-janitor-client/publish.sh
@@ -8,4 +8,4 @@ export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOL
  vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
 export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
  vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
-../gradlew test clean artifactoryPublish
+../gradlew test artifactoryPublish


### PR DESCRIPTION
it seems with `clean`, we'll end up generating an empty jar


cc @yonghaoy 