### PR TITLE
[No ticket] Pin setup-gcloud github action to version

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -57,7 +57,7 @@ jobs:
           echo ::set-output name=gcr-key::$GCR_KEY
           echo ::add-mask::$GCR_KEY
       - name: Auth to GCR
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '270.0.0'
           service_account_email: ${{ steps.vault-secret-step.outputs.gcr-email }}


### PR DESCRIPTION
This action is failing at master due to a warning from the maintainer about a branch migration. Recommendation is to pin to `v0`.

This caused a previous GHA failure here: https://github.com/DataBiosphere/terra-resource-janitor/actions/runs/2072622858