### PR TITLE
[PF-1557] Follow WSM pattern for publishing

### DIFF
--- a/.github/actions/bump-skip/action.yml
+++ b/.github/actions/bump-skip/action.yml
@@ -1,0 +1,28 @@
+# This action must be done after the checkout action
+name: 'bump-skip'
+description: 'Set skip-out when we are doing a version bump'
+author: 'dd'
+inputs:
+  event-name:
+    description: 'github.event_name from the calling workflow'
+    required: true
+outputs:
+  is-bump:
+    description: 'yes if this is a push made by bumper; no if it is a regular push'
+    value: ${{ steps.bumptest.outputs.is-bump }}
+runs:
+  using: "composite"
+  steps:
+  - name: Bump test
+    id: bumptest
+    run: |
+      log=$(git log --pretty='%B')
+      echo "log=$log"
+      pattern="^bump .*"
+      IS_BUMP=no
+      if [[ "${{ inputs.event-name }}" == "push" && "$log" =~ $pattern ]]; then
+        IS_BUMP=yes
+      fi
+      echo "IS_BUMP=$IS_BUMP"
+      echo ::set-output name=is-bump::$IS_BUMP
+    shell: bash

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -122,6 +122,7 @@ jobs:
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
       - name: Update Version Mapping
+        if: steps.skiptest.outputs.is-bump == 'no'
         uses: broadinstitute/repository-dispatch@master
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOTFIX_BRANCHES: hotfix.*
           OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
-          RELEASE_BRANCHES: msdtrt
+          RELEASE_BRANCHES: master
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^gradle.ext.janitorVersion\\s*=\\s*\".*\""
           VERSION_SUFFIX: SNAPSHOT

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -20,7 +20,7 @@ on:
       branch:
         description: 'Branch to run the workflow on'
         required: false
-        default: 'main'
+        default: 'master'
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GOOGLE_PROJECT: terra-kernel-k8s

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -6,7 +6,21 @@ on:
       - master
     paths-ignore:
       - 'README.md'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Part of the version to bump: major, minor, patch'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
+      branch:
+        description: 'Branch to run the workflow on'
+        required: false
+        default: 'main'
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GOOGLE_PROJECT: terra-kernel-k8s
@@ -17,18 +31,47 @@ jobs:
   tag-build-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Set part of semantic version to bump
+        id: controls
+        run: |
+          SEMVER_PART=""
+          CHECKOUT_BRANCH="$GITHUB_REF"
+          if ${{github.event_name == 'push' }}; then
+            SEMVER_PART="patch"
+          elif ${{github.event_name == 'workflow_dispatch' }}; then
+            SEMVER_PART=${{ github.event.inputs.bump }}
+            CHECKOUT_BRANCH=${{ github.event.inputs.branch }}
+          fi
+          echo ::set-output name=semver-part::$SEMVER_PART
+          echo ::set-output name=checkout-branch::$CHECKOUT_BRANCH
       - name: Checkout current code
         uses: actions/checkout@master
-      - name: Bump version and push tag
+        with:
+          ref: ${{ steps.controls.outputs.checkout-branch }}
+      - name: Skip version bump merges
+        id: skiptest
+        uses: ./.github/actions/bump-skip
+        with:
+          event-name: ${{ github.event_name }}
+      - name: Bump the tag to a new version
+        if: steps.skiptest.outputs.is-bump == 'no'
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
-        uses: broadinstitute/github-tag-action@master
         env:
+          DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: false
+          HOTFIX_BRANCHES: hotfix.*
+          OVERRIDE_BUMP: ${{ steps.controls.outputs.semver-part }}
+          RELEASE_BRANCHES: msdtrt
+          VERSION_FILE_PATH: settings.gradle
+          VERSION_LINE_MATCH: "^gradle.ext.janitorVersion\\s*=\\s*\".*\""
+          VERSION_SUFFIX: SNAPSHOT
       - name: Pull Vault image
+        if: steps.skiptest.outputs.is-bump == 'no'
         run: docker pull vault:1.1.0
       # Currently, there's no way to add capabilities to Docker actions on Git, and Vault needs IPC_LOCK to run.
       - name: Get Vault token
+        if: steps.skiptest.outputs.is-bump == 'no'
         id: vault-token-step
         run: |
           VAULT_TOKEN=$(docker run --rm --cap-add IPC_LOCK \
@@ -40,6 +83,7 @@ jobs:
           echo ::set-output name=vault-token::$VAULT_TOKEN
           echo ::add-mask::$VAULT_TOKEN
       - name: Get Vault secrets
+        if: steps.skiptest.outputs.is-bump == 'no'
         id: vault-secret-step
         run: |
           GCR_EMAIL=$(docker run --rm --cap-add IPC_LOCK \
@@ -57,20 +101,25 @@ jobs:
           echo ::set-output name=gcr-key::$GCR_KEY
           echo ::add-mask::$GCR_KEY
       - name: Auth to GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v0
         with:
           version: '270.0.0'
           service_account_email: ${{ steps.vault-secret-step.outputs.gcr-email }}
           service_account_key: ${{ steps.vault-secret-step.outputs.gcr-key }}
       - name: Explicitly auth Docker for GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
         run: gcloud auth configure-docker --quiet
       - name: Set up AdoptOpenJDK 11
+        if: steps.skiptest.outputs.is-bump == 'no'
         uses: joschi/setup-jdk@v2
         with:
           java-version: 11
       - name: Grant execute permission for gradlew
+        if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew
       - name: Build and push GCR image using Jib
+        if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
         env:
           SERVICE_VERSION: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -121,8 +121,6 @@ jobs:
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
-        env:
-          SERVICE_VERSION: ${{ steps.tag.outputs.tag }}
       - name: Update Version Mapping
         uses: broadinstitute/repository-dispatch@master
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = 'bio.terra'
-    version = System.getenv('SERVICE_VERSION') != null ? System.getenv('SERVICE_VERSION') : '0.8.0-SNAPSHOT'
+    version = gradle.janitorVersion
     sourceCompatibility = JavaVersion.VERSION_11
     ext {
         artifactGroup = "${group}.janitor"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ rootProject.name = 'terra-resource-janitor'
 include 'terra-resource-janitor-client'
 
 enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
+// The next line should only be changed by the BroadBot d.b.a. bumptagbot.
+gradle.ext.janitorVersion = "0.113.0-SNAPSHOT"


### PR DESCRIPTION
Janitor's `tag-build-push` workflow is currently broken because it uses `broadinstitute/github-tag-action` instead of `databiosphere/github-actions/actions/bumper`. The old action hasn't been updated since 2020, and recently broke due to git's mitigation of CVE-2022-24765 (see example workaround in https://github.com/DataBiosphere/github-actions/pull/32). Rather than fix a second bumper action, I think it makes sense to use the action currently supported by Broad devops.

This change includes:

- Swapping `broadinstitute/github-tag-action` to `databiosphere/github-actions/actions/bumper`, plus a handful of related changes inside the `tag-build-push` workflow inspired by [WSM's workflow](https://github.com/DataBiosphere/terra-workspace-manager/blob/main/.github/workflows/tag-publish.yml).
- Adding a top-level gradle version property to `settings.gradle`
- Adding a local `bump-skip` action copied from WSM. We should probably move this to a central place instead of copying it everywhere like we currently do, but I'm not sure the right way to do that.
