### PR TITLE
[PF-883] Store WSM url allowlist in Janitor config instead of using identifiers

### DIFF
--- a/src/main/java/bio/terra/janitor/app/configuration/WorkspaceManagerConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/WorkspaceManagerConfiguration.java
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "janitor.workspace-manager")
 public class WorkspaceManagerConfiguration {
 
-  // A map from instance IDs to Workspace Manager instance URLs, like:
-  // "dev" -> "https://workspace.dsde-dev.broadinstitute.org"
+  // A list of allowed Workspace Manager instance URLs, like:
+  // "https://workspace.dsde-dev.broadinstitute.org"
   private List<String> instances;
 
   public List<String> getInstances() {

--- a/src/main/java/bio/terra/janitor/app/configuration/WorkspaceManagerConfiguration.java
+++ b/src/main/java/bio/terra/janitor/app/configuration/WorkspaceManagerConfiguration.java
@@ -1,6 +1,6 @@
 package bio.terra.janitor.app.configuration;
 
-import java.util.HashMap;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -12,13 +12,13 @@ public class WorkspaceManagerConfiguration {
 
   // A map from instance IDs to Workspace Manager instance URLs, like:
   // "dev" -> "https://workspace.dsde-dev.broadinstitute.org"
-  private HashMap<String, String> instances;
+  private List<String> instances;
 
-  public HashMap<String, String> getInstances() {
+  public List<String> getInstances() {
     return instances;
   }
 
-  public void setInstances(HashMap<String, String> instances) {
+  public void setInstances(List<String> instances) {
     this.instances = instances;
   }
 }

--- a/src/main/java/bio/terra/janitor/service/workspace/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/janitor/service/workspace/WorkspaceManagerService.java
@@ -7,7 +7,6 @@ import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
 import bio.terra.workspace.client.ApiException;
 import com.google.auth.oauth2.AccessToken;
-import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.client.Client;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,13 +43,12 @@ public class WorkspaceManagerService {
     return workspaceClient;
   }
 
-  public void deleteWorkspace(UUID workspaceId, String testUser, String instanceId)
+  public void deleteWorkspace(UUID workspaceId, String testUser, String wsmUrl)
       throws ApiException {
     AccessToken userAccessToken = iamService.impersonateTestUser(testUser);
-    String wsmUrl =
-        Optional.ofNullable(workspaceManagerConfiguration.getInstances().get(instanceId))
-            .orElseThrow(
-                () -> new InvalidResourceUidException("Invalid workspace instance identifier"));
+    if (!workspaceManagerConfiguration.getInstances().contains(wsmUrl)) {
+      throw new InvalidResourceUidException("Invalid workspace instance url provded");
+    }
     WorkspaceApi workspaceClient = getWorkspaceApi(userAccessToken.getTokenValue(), wsmUrl);
     workspaceClient.deleteWorkspace(workspaceId);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,7 @@ janitor:
     retention-check-interval: 1d
     completed-flight-retention: 7d
   workspace-manager:
-    instances:
-      dev: https://workspace.dsde-dev.broadinstitute.org
-      wsmtest: https://workspace.wsmtest.integ.envs.broadinstitute.org
+    instances: ["https://workspace.dsde-dev.broadinstitute.org", "https://workspace.wsmtest.integ.envs.broadinstitute.org"]
   azure:
     managed-app-client-id: ${AZURE_MANAGED_APP_CLIENT_ID}
     managed-app-client-secret: ${AZURE_MANAGED_APP_CLIENT_SECRET}

--- a/src/main/resources/static/service_openapi.yaml
+++ b/src/main/resources/static/service_openapi.yaml
@@ -548,8 +548,8 @@ components:
         workspaceManagerInstance:
           type: string
           description: |
-            The Workspace Manager instance which manages this workspace. This must be a key
-            in Janitor's configured instance set, like `dev`.
+            The URL of the Workspace Manager instance which manages this workspace. This must be
+            in Janitor's configured allowlist.
 
     # A cloud resource unique identifier. Each CloudResourceUid represents exactly one cloud resource.
     # We are not doing polymorphism at this moment because of lack of support in swagger-codegen or openApiGenerator


### PR DESCRIPTION
Mapping identifiers to WSM urls meant we needed to keep hardcoded strings in sync across services, using urls in requests avoids this. However, we're still using a config-based allowlist, which prevents users from forcing Janitor to call arbitrary urls.

See usage in https://github.com/DataBiosphere/terra-cli/pull/246