### PR TITLE
Fix GHA secret masking

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -81,8 +81,8 @@ jobs:
             vault write -field token \
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
-          echo ::set-output name=vault-token::$VAULT_TOKEN
           echo ::add-mask::$VAULT_TOKEN
+          echo ::set-output name=vault-token::$VAULT_TOKEN
       - name: Get Vault secrets
         if: steps.skiptest.outputs.is-bump == 'no'
         id: vault-secret-step
@@ -97,10 +97,10 @@ jobs:
             -e "VAULT_ADDR=${VAULT_ADDR}" \
             vault:1.1.0 \
             vault read -field ci-gcr-sa-key ${VAULT_PATH_GCR})
-          echo ::set-output name=gcr-email::$GCR_EMAIL
           echo ::add-mask::$GCR_EMAIL
-          echo ::set-output name=gcr-key::$GCR_KEY
+          echo ::set-output name=gcr-email::$GCR_EMAIL
           echo ::add-mask::$GCR_KEY
+          echo ::set-output name=gcr-key::$GCR_KEY
       - name: Auth to GCR
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
             vault write -field token \
               auth/approle/login role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }} \
               secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }})
-          echo ::set-output name=vault-token::$VAULT_TOKEN
           echo ::add-mask::$VAULT_TOKEN
+          echo ::set-output name=vault-token::$VAULT_TOKEN
       - name: Grant execute permission for render-config
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x local-dev/render-config.sh


### PR DESCRIPTION
(Same situation as https://github.com/DataBiosphere/terra-resource-buffer/pull/244)
These workflows are masking secrets incorrectly, the masking needs to happen before setting them as output. If this workflow is run with debug logging (which it isn't), the current pattern will leak secrets.