### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -113,9 +113,10 @@ jobs:
         run: gcloud auth configure-docker --quiet
       - name: Set up AdoptOpenJDK 11
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Grant execute permission for gradlew
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,10 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up AdoptOpenJDK 11
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: actions/cache@v2


### PR DESCRIPTION
The `joschi/setup-jdk@v2` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice