### PR TITLE
[PF-940] Use broad-appsec-blessed JRE image

### DIFF
--- a/gradle/jib.gradle
+++ b/gradle/jib.gradle
@@ -18,7 +18,8 @@ task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
 
 jib {
     from {
-        image = 'eclipse-temurin:17.0.4_8-jre'
+        // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
+        image = 'us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian'
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
Problem statement - Standard eclipse temurin images potentially have app-security concerns
Fix - use the broad app-security-approved images from https://github.com/broadinstitute/dsp-appsec-blessed-images

No further checks were performed since the major version is the same, minor version is a downgrade
