### PR TITLE
[PF-2168] Move from terra-kernel-k8s to broad-dsp-gcr-public

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -21,8 +21,6 @@ on:
         default: 'master'
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
-  GOOGLE_PROJECT: terra-kernel-k8s
-  GKE_CLUSTER: terra-kernel-k8s
   VAULT_PATH_GCR: secret/dsde/terra/kernel/test
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
 jobs:
@@ -120,7 +118,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
-        run: "./gradlew jib --image=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
+        run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
       - name: Update Version Mapping
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: broadinstitute/repository-dispatch@master

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -99,11 +99,13 @@ jobs:
           echo ::set-output name=gcr-key::$GCR_KEY
       - name: Auth to GCR
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/auth@v1
         with:
-          version: '270.0.0'
-          service_account_email: ${{ steps.vault-secret-step.outputs.gcr-email }}
-          service_account_key: ${{ steps.vault-secret-step.outputs.gcr-key }}
+          version: '411.0.0'
+          credentials_json: ${{ steps.vault-secret-step.outputs.gcr-key }}
+      - name: Setup gcloud
+        if: steps.skiptest.outputs.is-bump == 'no'
+        uses: google-github-actions/setup-gcloud@v1
       - name: Explicitly auth Docker for GCR
         if: steps.skiptest.outputs.is-bump == 'no'
         run: gcloud auth configure-docker --quiet

--- a/local-dev/skaffold.yaml.template
+++ b/local-dev/skaffold.yaml.template
@@ -3,7 +3,7 @@ apiVersion: skaffold/v2beta17
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/terra-kernel-k8s/terra-resource-janitor
+  - image: gcr.io/broad-dsp-gcr-public/terra-resource-janitor
     context: ../
     jib: {}
 deploy:


### PR DESCRIPTION
This needs to be merged (and a new image needs to be published) before the equivalent helmfile change can merge. This also fixes the publish workflow, equivalent to https://github.com/DataBiosphere/terra-resource-buffer/pull/259