### PR TITLE
[PF-2478] Only run checks when PR targets default branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,13 @@
 name: Run Tests
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ master ]
     paths-ignore: [ '**.md' ]
   pull_request:
     # Branch settings require status checks before merging, so don't add paths-ignore.
-    branches: [ '**' ]
+    branches: [ master ]
 
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
@@ -20,6 +21,7 @@ env:
   SERVICE_ACCOUNT_FILE: src/test/resources/rendered/sa-account.json
   SERVICE_ACCOUNT_CLIENT_FILE: src/test/resources/rendered/client-sa-account.json
   SERVICE_ACCOUNT_CLOUD_ACCESS_FILE: src/test/resources/rendered/cloud-access-sa-account.json
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only run PR checks when the PR targets primary/default branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.

ref - 
- https://github.com/DataBiosphere/terra-workspace-manager/pull/1061
- https://broadworkbench.atlassian.net/browse/PF-2478