### PR TITLE
[PF-2511] Fix workflow to notify Broad devops

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -91,10 +91,10 @@ jobs:
   report-to-sherlock:
     # Report new version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: tag-publish-job
-    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    needs: tag-build-push
+    if: ${{ needs.tag-build-push.outputs.is-bump == 'no' }}
     with:
-      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.tag-build-push.outputs.tag }}
       chart-name: 'crljanitor'
     permissions:
       contents: 'read'

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -24,6 +24,9 @@ env:
 jobs:
   tag-build-push:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      is-bump: ${{ steps.skiptest.outputs.is-bump }}
     steps:
       - name: Set part of semantic version to bump
         id: controls
@@ -85,11 +88,14 @@ jobs:
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"
-      - name: Update Version Mapping
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "crljanitor", "version": "${{ steps.tag.outputs.tag }}"}'
+  report-to-sherlock:
+    # Report new version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: tag-publish-job
+    if: ${{ needs.tag-publish-job.outputs.is-bump == 'no' }}
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'crljanitor'
+    permissions:
+      contents: 'read'
+      id-token: 'write'


### PR DESCRIPTION
The existing `repository-dispatch` based notification flow is broken, and publishing workflows have been broken for several weeks (though only one real PR was added in that time).

Janitor is not deployed in Broad dev, so I'm not including the "push to dev" step in this workflow.