### PR TITLE
Automatically publish client library on merge to main

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -85,6 +85,13 @@ jobs:
       - name: Grant execute permission for gradlew
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew
+      - name: "Publish client to Artifactory"
+        if: steps.skiptest.outputs.is-bump == 'no'
+        run: ./gradlew artifactoryPublish
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -13,10 +13,12 @@ gradle.taskGraph.whenReady { taskGraph ->
 publishing {
     publications {
         janitorClientLibrary(MavenPublication) {
-            groupId = gradle.projectGroup
-            artifactId = rootProject.name
-            version = gradle.janitorVersion
             from components.java
+            versionMapping {
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This adds an additional step to automatically publish a new client library version every time a PR is merged to main. This also fixes an issue with the `artifactoryPublish` action, which wasn't working properly