### PR TITLE
PF-2979 followup: fix metrics

### DIFF
--- a/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
@@ -190,6 +190,7 @@ class FlightManager {
       boolean flightCompleted = completeFlight(resourceAndFlight);
       metricsHelper.incrementCompletion(
           new ResourceTypeVisitor().accept(resourceAndFlight.trackedResource().cloudResourceUid()),
+          resourceAndFlight.trackedResource().trackedResourceState(),
           flightCompleted);
       metricsHelper.recordCompletionDuration(
           Duration.ofNanos(stopwatch.elapsed(TimeUnit.NANOSECONDS)), flightCompleted);

--- a/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/FlightManager.java
@@ -78,6 +78,8 @@ class FlightManager {
       // No resource to schedule.
       return Optional.empty();
     }
+    metricsHelper.incrementSubmission(
+        new ResourceTypeVisitor().accept(resource.get().cloudResourceUid()));
     // If submission fails, it will be recovered later.
     boolean submissionSuccessful = submitToStairway(flightId, resource.get());
     // Only record duration of submission if there was something to attempt to schedule.
@@ -186,6 +188,9 @@ class FlightManager {
     for (TrackedResourceAndFlight resourceAndFlight : resourceAndFlights) {
       Stopwatch stopwatch = Stopwatch.createStarted();
       boolean flightCompleted = completeFlight(resourceAndFlight);
+      metricsHelper.incrementCompletion(
+          new ResourceTypeVisitor().accept(resourceAndFlight.trackedResource().cloudResourceUid()),
+          flightCompleted);
       metricsHelper.recordCompletionDuration(
           Duration.ofNanos(stopwatch.elapsed(TimeUnit.NANOSECONDS)), flightCompleted);
       if (flightCompleted) {

--- a/src/main/java/bio/terra/janitor/service/cleanup/FlightScheduler.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/FlightScheduler.java
@@ -144,7 +144,7 @@ public class FlightScheduler {
         // 0 counts, we need to make sure to update metrics measurements that may have changed to 0.
         // If we don't, the last non-zero value will continue to be exported.
         int count = stateCounts.getOrDefault(state, 0);
-        metricsHelper.recordResourceKindCount(kind, state, count);
+        metricsHelper.recordResourceKindGauge(kind, state, count);
       }
     }
     logger.info("Done recording resource counts.");

--- a/src/main/java/bio/terra/janitor/service/cleanup/MetricsHelper.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/MetricsHelper.java
@@ -141,13 +141,16 @@ public class MetricsHelper implements AutoCloseable {
     completionDuration.record(duration.toMillis(), attributes);
   }
 
-  public void incrementCompletion(ResourceType resourceType, boolean flightCompleted) {
+  public void incrementCompletion(
+      ResourceType resourceType, TrackedResourceState state, boolean flightCompleted) {
     Attributes attributes =
         Attributes.of(
             SUCCESS_KEY,
             Boolean.toString(flightCompleted),
             RESOURCE_TYPE_KEY,
-            resourceType.toString());
+            resourceType.toString(),
+            RESOURCE_STATE_KEY,
+            state.toString());
     completionCount.add(1, attributes);
   }
 

--- a/src/main/java/bio/terra/janitor/service/cleanup/MetricsHelper.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/MetricsHelper.java
@@ -1,23 +1,31 @@
 package bio.terra.janitor.service.cleanup;
 
 import bio.terra.janitor.db.ResourceKind;
+import bio.terra.janitor.db.ResourceType;
 import bio.terra.janitor.db.TrackedResourceState;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
 
 /** Helper class for recording metrics associated with cleanup. */
 @Component
-public class MetricsHelper {
+public class MetricsHelper implements AutoCloseable {
   private static final String PREFIX = "terra/janitor/cleanup";
   public static final String SUBMISSION_DURATION_METER_NAME = PREFIX + "/submission_duration";
+  public static final String SUBMISSION_COUNT_METER_NAME = PREFIX + "/submission_count";
   public static final String COMPLETION_DURATION_METER_NAME = PREFIX + "/completion_duration";
+  public static final String COMPLETION_COUNT_METER_NAME = PREFIX + "/completion_count";
   public static final String FATAL_UPDATE_DURATION_METER_NAME = PREFIX + "/fatal_update_duration";
-  public static final String TRACKED_RESOURCE_COUNT_METER_NAME = PREFIX + "/tracked_resource_count";
+  public static final String FATAL_UPDATE_COUNT_METER_NAME = PREFIX + "/fatal_update_count";
+  public static final String TRACKED_RESOURCE_GAUGE_METER_NAME = PREFIX + "/tracked_resource_gauge";
   public static final String RECOVERED_SUBMITTED_FLIGHTS_COUNT_METER_NAME =
       PREFIX + "/recovered_submitted_flights_count";
   public static final String FATAL_FLIGHT_UNDELETED_COUNT_METER_NAME =
@@ -36,11 +44,20 @@ public class MetricsHelper {
   private static final String COUNT = "1";
 
   private final DoubleHistogram submissionDuration;
+  private final LongCounter submissionCount;
   private final DoubleHistogram completionDuration;
+  private final LongCounter completionCount;
   private final DoubleHistogram fatalUpdateDuration;
-  private final LongCounter trackedResourceCount;
+  private final ObservableLongGauge trackedResourceGauge;
   private final LongCounter recoveredSubmittedFlightsCount;
   private final LongCounter fatalFlightUndeletedCount;
+
+  /**
+   * Gauges are read via callback. We need to keep track of the current ready resource ratio for
+   * each pool id. They will be read as needed by readyResourceRatioGauge.
+   */
+  private final ConcurrentHashMap<Pair<TrackedResourceState, ResourceKind>, Long>
+      currentTrackedResourceCount = new ConcurrentHashMap<>();
 
   public MetricsHelper(OpenTelemetry openTelemetry) {
     var meter = openTelemetry.getMeter(bio.terra.common.stairway.MetricsHelper.class.getName());
@@ -50,11 +67,23 @@ public class MetricsHelper {
             .setDescription("Duration of a cleanup flight submission.")
             .setUnit(MILLISECOND)
             .build();
+    this.submissionCount =
+        meter
+            .counterBuilder(SUBMISSION_COUNT_METER_NAME)
+            .setDescription("Counter of cleanup flight submissions.")
+            .setUnit(COUNT)
+            .build();
     this.completionDuration =
         meter
             .histogramBuilder(COMPLETION_DURATION_METER_NAME)
             .setDescription("Duration of a cleanup flight completion.")
             .setUnit(MILLISECOND)
+            .build();
+    this.completionCount =
+        meter
+            .counterBuilder(COMPLETION_COUNT_METER_NAME)
+            .setDescription("Counter of cleanup flight completions.")
+            .setUnit(COUNT)
             .build();
     this.fatalUpdateDuration =
         meter
@@ -62,12 +91,23 @@ public class MetricsHelper {
             .setDescription("Duration of a cleanup flight fatal update.")
             .setUnit(MILLISECOND)
             .build();
-    this.trackedResourceCount =
+    this.trackedResourceGauge =
         meter
-            .counterBuilder(TRACKED_RESOURCE_COUNT_METER_NAME)
-            .setDescription("Counts of the number of tracked resources.")
+            .gaugeBuilder(TRACKED_RESOURCE_GAUGE_METER_NAME)
+            .setDescription("Gauge of the current number of tracked resources.")
             .setUnit(COUNT)
-            .build();
+            .ofLongs()
+            .buildWithCallback(
+                (ObservableLongMeasurement m) ->
+                    currentTrackedResourceCount.forEach(
+                        (stateAndKind, count) ->
+                            m.record(
+                                count,
+                                Attributes.of(
+                                    RESOURCE_STATE_KEY, stateAndKind.getLeft().toString(),
+                                    RESOURCE_TYPE_KEY,
+                                        stateAndKind.getRight().resourceType().toString(),
+                                    CLIENT_KEY, stateAndKind.getRight().client()))));
     this.recoveredSubmittedFlightsCount =
         meter
             .counterBuilder(RECOVERED_SUBMITTED_FLIGHTS_COUNT_METER_NAME)
@@ -90,10 +130,25 @@ public class MetricsHelper {
     submissionDuration.record(duration.toMillis(), attributes);
   }
 
+  public void incrementSubmission(ResourceType resourceType) {
+    var attributes = Attributes.of(RESOURCE_TYPE_KEY, resourceType.toString());
+    submissionCount.add(1, attributes);
+  }
+
   /** Record the duration of an attempt to complete a cleanup flight. */
   public void recordCompletionDuration(Duration duration, boolean flightCompleted) {
     Attributes attributes = Attributes.of(SUCCESS_KEY, Boolean.toString(flightCompleted));
     completionDuration.record(duration.toMillis(), attributes);
+  }
+
+  public void incrementCompletion(ResourceType resourceType, boolean flightCompleted) {
+    Attributes attributes =
+        Attributes.of(
+            SUCCESS_KEY,
+            Boolean.toString(flightCompleted),
+            RESOURCE_TYPE_KEY,
+            resourceType.toString());
+    completionCount.add(1, attributes);
   }
 
   /**
@@ -105,13 +160,8 @@ public class MetricsHelper {
   }
 
   /** Records the latest count of {@link ResourceKind}. */
-  public void recordResourceKindCount(ResourceKind kind, TrackedResourceState state, int count) {
-    Attributes attributes =
-        Attributes.of(
-            RESOURCE_STATE_KEY, state.toString(),
-            RESOURCE_TYPE_KEY, kind.resourceType().toString(),
-            CLIENT_KEY, kind.client());
-    trackedResourceCount.add(count, attributes);
+  public void recordResourceKindGauge(ResourceKind kind, TrackedResourceState state, long count) {
+    currentTrackedResourceCount.put(Pair.of(state, kind), count);
   }
 
   /**
@@ -128,5 +178,10 @@ public class MetricsHelper {
    */
   public void incrementFatalFlightUndeleted() {
     fatalFlightUndeletedCount.add(1);
+  }
+
+  @Override
+  public void close() throws Exception {
+    trackedResourceGauge.close();
   }
 }

--- a/src/main/java/bio/terra/janitor/service/cleanup/MetricsViews.java
+++ b/src/main/java/bio/terra/janitor/service/cleanup/MetricsViews.java
@@ -25,6 +25,20 @@ public class MetricsViews {
             .build());
   }
 
+  @Bean(name = MetricsHelper.SUBMISSION_COUNT_METER_NAME)
+  public Pair<InstrumentSelector, View> submissionCountView() {
+    return Pair.of(
+        InstrumentSelector.builder()
+            .setMeterName(MetricsHelper.SUBMISSION_COUNT_METER_NAME)
+            .build(),
+        View.builder()
+            .setName(MetricsHelper.SUBMISSION_COUNT_METER_NAME)
+            .setDescription("Counter of cleanup flight submissions")
+            .setAggregation(Aggregation.sum())
+            .setAttributeFilter(Set.of(MetricsHelper.SUCCESS_KEY.getKey()))
+            .build());
+  }
+
   @Bean(name = MetricsHelper.COMPLETION_DURATION_METER_NAME)
   public Pair<InstrumentSelector, View> completionDurationView() {
     return Pair.of(
@@ -35,6 +49,20 @@ public class MetricsViews {
             .setName(MetricsHelper.COMPLETION_DURATION_METER_NAME)
             .setDescription("Duration of a cleanup flight completion")
             .setAggregation(Aggregation.base2ExponentialBucketHistogram())
+            .setAttributeFilter(Set.of(MetricsHelper.SUCCESS_KEY.getKey()))
+            .build());
+  }
+
+  @Bean(name = MetricsHelper.COMPLETION_COUNT_METER_NAME)
+  public Pair<InstrumentSelector, View> completionCountView() {
+    return Pair.of(
+        InstrumentSelector.builder()
+            .setMeterName(MetricsHelper.COMPLETION_COUNT_METER_NAME)
+            .build(),
+        View.builder()
+            .setName(MetricsHelper.COMPLETION_COUNT_METER_NAME)
+            .setDescription("Counter of cleanup flight completions")
+            .setAggregation(Aggregation.sum())
             .setAttributeFilter(Set.of(MetricsHelper.SUCCESS_KEY.getKey()))
             .build());
   }
@@ -53,16 +81,16 @@ public class MetricsViews {
             .build());
   }
 
-  @Bean(name = MetricsHelper.TRACKED_RESOURCE_COUNT_METER_NAME)
-  public Pair<InstrumentSelector, View> trackedResourceCountView() {
+  @Bean(name = MetricsHelper.TRACKED_RESOURCE_GAUGE_METER_NAME)
+  public Pair<InstrumentSelector, View> trackedResourceGaugeView() {
     return Pair.of(
         InstrumentSelector.builder()
-            .setMeterName(MetricsHelper.TRACKED_RESOURCE_COUNT_METER_NAME)
+            .setMeterName(MetricsHelper.TRACKED_RESOURCE_GAUGE_METER_NAME)
             .build(),
         View.builder()
-            .setName(MetricsHelper.TRACKED_RESOURCE_COUNT_METER_NAME)
-            .setDescription("Counts of the number of tracked resources")
-            .setAggregation(Aggregation.sum())
+            .setName(MetricsHelper.TRACKED_RESOURCE_GAUGE_METER_NAME)
+            .setDescription("Gauge of the current number of tracked resources")
+            .setAggregation(Aggregation.lastValue())
             .setAttributeFilter(
                 Set.of(
                     MetricsHelper.RESOURCE_STATE_KEY.getKey(),

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
@@ -138,7 +138,7 @@ public class FlightSchedulerTest extends BaseUnitTest {
         .untilAsserted(
             () ->
                 verify(mockMetricsHelper)
-                    .recordResourceKindCount(
+                    .recordResourceKindGauge(
                         ResourceKind.create("", ResourceType.GOOGLE_BUCKET),
                         resource.trackedResourceState(),
                         1));


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PF-2979

Follow-up to https://github.com/DataBiosphere/terra-resource-janitor/pull/171

The OpenTelemetry -> Google export is working, but I discovered some issues when looking at metrics.

1. I was interpreting `trackedResourceCount` as a counter when it should be a gauge, leading to weirdness in the dashboards.
2. Janitor doesn't actually have counters for resource cleanup submissions and completions -- just gauges and timing histograms. So I added some counters to be able to see rates of resource cleanups over time. The gauges are less useful IMO because there are so many DONE records.