### PR TITLE
CORE-250: upgrade Postgres to 16.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12.3
+        image: postgres:14.15
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14.15
+        image: postgres:16.6
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/local-dev/local-postgres-init.sql
+++ b/local-dev/local-postgres-init.sql
@@ -1,4 +1,5 @@
-CREATE DATABASE testdb;
-CREATE DATABASE testdb_stairway;
 CREATE ROLE dbuser WITH LOGIN ENCRYPTED PASSWORD 'dbpwd';
 CREATE ROLE dbuser_stairway WITH LOGIN ENCRYPTED PASSWORD 'dbpwd_stairway';
+
+CREATE DATABASE testdb OWNER dbuser;
+CREATE DATABASE testdb_stairway OWNER dbuser_stairway;

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-POSTGRES_VERSION=14.15
+POSTGRES_VERSION=16.6
 start() {
 
 

--- a/local-dev/run_postgres.sh
+++ b/local-dev/run_postgres.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-POSTGRES_VERSION=12.3
+POSTGRES_VERSION=14.15
 start() {
 
 


### PR DESCRIPTION
Upgrades unit tests and local development to Postgres 16.6.

The unit tests passed 10 times in a row in GHA for this PR (I re-ran it manually). I do see intermittent unit test failures when running locally - but they're not consistent, and different test cases fail on different runs. I am inclined to write that off as an environmental issue. When running locally, unit tests pass about half the time with only one test causing each failure.

We _could_ go all the way to Postgres 17. However, Postgres 16 is the GCP default (see [here](https://cloud.google.com/sql/docs/postgres/db-versions)) and in my opinion this is not the place to push the envelope, nor would Janitor particularly benefit from the newer version. Postgres 16 does not hit extended support charges until February 1, 2029.

