### PR TITLE
[CORE-265] Replace toolsalpha with qa env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         run: ./gradlew integrationTest --scan
       - name: Upload Test Reports
         if: always() && steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Reports
           path: build/reports/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ env:
   JANITOR_CLIENT_SA_FILE: src/test/resources/rendered/client-sa-account.json
   JANITOR_CLIENT_SA_TOOLS_FILE: src/test/resources/rendered/tools-client-sa-account.json
   JANITOR_CLOUD_ACCESS_SA_FILE: src/test/resources/rendered/cloud-access-sa-account.json
-  LOCAL_PROPERTIES_DIR: config
-
+  LOCAL_PROPERTIES_DIRECTORY: config
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -68,16 +67,16 @@ jobs:
           JANITOR_CLOUD_ACCESS_SA=$(echo $JANITOR_CLOUD_ACCESS_SA_B64 | base64 --decode)
           echo ::add-mask::$JANITOR_CLOUD_ACCESS_SA
           echo $JANITOR_CLOUD_ACCESS_SA > $JANITOR_CLOUD_ACCESS_SA_FILE
-
+          
           AZURE_PUBLISHER_CLIENT_ID=${{ secrets.AZURE_PUBLISHER_CLIENT_ID }}
           echo ::add-mask::$AZURE_PUBLISHER_CLIENT_ID
           AZURE_PUBLISHER_CLIENT_SECRET=${{ secrets.AZURE_PUBLISHER_CLIENT_SECRET }}
           echo ::add-mask::$AZURE_PUBLISHER_CLIENT_SECRET
           AZURE_PUBLISHER_TENANT_ID=${{ secrets.AZURE_PUBLISHER_TENANT_ID }}
           echo ::add-mask::$AZURE_PUBLISHER_TENANT_ID
-
-          mkdir -p "${LOCAL_PROPERTIES_DIR}"
-          cat << EOF > ${LOCAL_PROPERTIES_DIR}/local-properties.yml
+          
+          mkdir -p "${LOCAL_PROPERTIES_DIRECTORY}"
+          cat << EOF > ${LOCAL_PROPERTIES_DIRECTORY}/local-properties.yml
           janitor:
             azure:
               managed-app-client-id: ${AZURE_PUBLISHER_CLIENT_ID}

--- a/local-dev/render-config.sh
+++ b/local-dev/render-config.sh
@@ -8,7 +8,7 @@
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
 VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/app-sa
-VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/client-sa
+VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/client-sa
 VAULT_CLOUD_ACCESS_SERVICE_ACCOUNT_PATH=secret/dsde/terra/janitor-test/default/cloud-access-sa
 VAULT_AZURE_MANAGED_APP_PUBLISHER_PATH=secret/dsde/terra/azure/common/managed-app-publisher
 

--- a/local-dev/render-config.sh
+++ b/local-dev/render-config.sh
@@ -7,7 +7,7 @@
 # TODO: migrate vault secrets to GSM as needed
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
-VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/app-sa
+VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/app-sa
 VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/client-sa
 VAULT_CLOUD_ACCESS_SERVICE_ACCOUNT_PATH=secret/dsde/terra/janitor-test/default/cloud-access-sa
 VAULT_AZURE_MANAGED_APP_PUBLISHER_PATH=secret/dsde/terra/azure/common/managed-app-publisher

--- a/local-dev/render-config.sh
+++ b/local-dev/render-config.sh
@@ -7,13 +7,13 @@
 # TODO: migrate vault secrets to GSM as needed
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
-VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/app-sa
-VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/client-sa
 VAULT_CLOUD_ACCESS_SERVICE_ACCOUNT_PATH=secret/dsde/terra/janitor-test/default/cloud-access-sa
 VAULT_AZURE_MANAGED_APP_PUBLISHER_PATH=secret/dsde/terra/azure/common/managed-app-publisher
 
 # GSM secrets
 GSM_CLIENT_SERVICE_ACCOUNT_SECRET=crljanitor-client-sa
+GSM_QA_APP_SERVICE_ACCOUNT_SECRET=crljanitor-qa-sa
+GSM_QA_CLIENT_SERVICE_ACCOUNT_SECRET=crljanitor-client-qa-sa
 GSM_CLIENT_SERVICE_ACCOUNT_PROJECT=broad-dsde-qa
 
 # Rendered paths
@@ -25,13 +25,6 @@ AZURE_MANAGED_APP_PUBLISHER_OUTPUT_FILE_PATH="$(dirname $0)"/../src/test/resourc
 LOCAL_PROPERTIES_DIR="$(dirname $0)"/../config
 
 # Pull secrets from vault
-docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json ${VAULT_SERVICE_ACCOUNT_PATH} \
-            | jq -r .data.key | base64 -d > ${SERVICE_ACCOUNT_OUTPUT_FILE_PATH}
-docker run --rm --cap-add IPC_LOCK \
-            -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json ${VAULT_CLIENT_SERVICE_ACCOUNT_PATH} \
-            | jq -r .data.key | base64 -d > ${CLIENT_SERVICE_ACCOUNT_OUTPUT_FILE_PATH}
 docker run --rm --cap-add IPC_LOCK \
             -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${VAULT_CLOUD_ACCESS_SERVICE_ACCOUNT_PATH} \
@@ -44,6 +37,12 @@ docker run --rm --cap-add IPC_LOCK \
 # Pull secrets from GSM
 gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret $GSM_CLIENT_SERVICE_ACCOUNT_SECRET \
   | jq -r '.key' | base64 -d > "$TOOLS_CLIENT_SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
+
+gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret GSM_QA_APP_SERVICE_ACCOUNT_SECRET \
+  | jq -r '.key' | base64 -d > "$SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
+
+gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret $GSM_QA_CLIENT_SERVICE_ACCOUNT_SECRET \
+  | jq -r '.key' | base64 -d > "$CLIENT_SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
 
 # Write the Azure configuration into the local-properties.yml file
 mkdir -p "${LOCAL_PROPERTIES_DIR}"

--- a/local-dev/render-config.sh
+++ b/local-dev/render-config.sh
@@ -7,8 +7,8 @@
 # TODO: migrate vault secrets to GSM as needed
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
-VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/app-sa
-VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/toolsalpha/crl_janitor/client-sa
+VAULT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/app-sa
+VAULT_CLIENT_SERVICE_ACCOUNT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/client-sa
 VAULT_CLOUD_ACCESS_SERVICE_ACCOUNT_PATH=secret/dsde/terra/janitor-test/default/cloud-access-sa
 VAULT_AZURE_MANAGED_APP_PUBLISHER_PATH=secret/dsde/terra/azure/common/managed-app-publisher
 

--- a/local-dev/render-config.sh
+++ b/local-dev/render-config.sh
@@ -38,7 +38,7 @@ docker run --rm --cap-add IPC_LOCK \
 gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret $GSM_CLIENT_SERVICE_ACCOUNT_SECRET \
   | jq -r '.key' | base64 -d > "$TOOLS_CLIENT_SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
 
-gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret GSM_QA_APP_SERVICE_ACCOUNT_SECRET \
+gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret $GSM_QA_APP_SERVICE_ACCOUNT_SECRET \
   | jq -r '.key' | base64 -d > "$SERVICE_ACCOUNT_OUTPUT_FILE_PATH"
 
 gcloud secrets versions access latest --project $GSM_CLIENT_SERVICE_ACCOUNT_PROJECT --secret $GSM_QA_CLIENT_SERVICE_ACCOUNT_SECRET \

--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -715,7 +715,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   }
 
   /** Clean up a fake WSM workspace. */
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_terraWorkspace() throws Exception {
     // Cleaning up workspaces relies on domain-wide delegation to impersonate test users. The tools
@@ -737,7 +736,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   }
 
   /** Try to clean up an already deleted workspace, should succeed. */
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_alreadyDeletedTerraWorkspace() throws Exception {
     UUID fakeWorkspaceId = UUID.randomUUID();

--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -206,7 +206,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     publisher.shutdown();
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleBucket() throws Exception {
     // Creates bucket and verify.
@@ -230,7 +229,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   }
 
   /** Try to let Janitor cleanup a Bucket that is already deleted in cloud. */
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_alreadyDeletedBucket() throws Exception {
     // Creates bucket and verify.
@@ -248,7 +246,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     publishAndVerify(resource, ResourceState.DONE);
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleBlob() throws Exception {
     // Creates Blob and verify.
@@ -273,7 +270,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   }
 
   /** Try to let Janitor cleanup a Blob that is already deleted in cloud. */
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_alreadyDeletedBlob() throws Exception {
     // Creates Blob and verify.
@@ -298,7 +294,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     storageCow.delete(bucketName);
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleDataset() throws Exception {
     // Creates dataset and table.
@@ -371,7 +366,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     publishAndVerify(tableUid, ResourceState.DONE);
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleBigQueryTable() throws Exception {
     // Creates dataset and table.
@@ -431,7 +425,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     bigQueryCow.datasets().delete(projectId, datasetName).execute();
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleNotebookInstance() throws Exception {
     InstanceName instanceName =
@@ -458,7 +451,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     assertEquals(404, e.getStatusCode());
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_alreadyDeletedGoogleNotebookInstance() throws Exception {
     InstanceName instanceName =
@@ -496,7 +488,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     assertEquals(404, e.getStatusCode());
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_googleProject() throws Exception {
     String projectId = randomProjectId();
@@ -513,7 +504,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     assertEquals("DELETE_REQUESTED", project.getState());
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_alreadyDeletedGoogleProject() throws Exception {
     String projectId = randomProjectId();
@@ -529,7 +519,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     assertEquals("DELETE_REQUESTED", project.getState());
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_neverCreatedGoogleProject_withMetadataOk()
       throws Exception {
@@ -550,7 +539,6 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
     publishAndVerify(request, ResourceState.DONE);
   }
 
-  @Disabled
   @Test
   public void subscribeAndCleanupResource_neverCreatedGoogleProject_withoutMetadataError()
       throws Exception {

--- a/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
@@ -22,19 +22,19 @@ public class TestConfiguration {
   /** pubsub project id to publish track resource to Janitor test env(qa) */
   private String resourceProjectId;
 
-  /** pubsub project id to publish track resource to Janitor prod env(qa) */
+  /** pubsub project id to publish track resource to Janitor prod env(tools) */
   private String prodTrackResourceProjectId;
 
   /** pubsub topic id to publish track resource to Janitor test env(qa) */
   private String trackResourceTopicId;
 
-  /** pubsub topic id to publish track resource to Janitor prod env(qa) */
+  /** pubsub topic id to publish track resource to Janitor prod env(tools) */
   private String prodTrackResourceTopicId;
 
   /** Credential file path to be able to publish message to Janitor test env (qa). */
   private String janitorClientServiceAccountPath;
 
-  /** Credential file path to be able to publish message to Janitor prod env (qa). */
+  /** Credential file path to be able to publish message to Janitor prod env (tools). */
   private String prodJanitorClientCredentialFilePath;
 
   /** Credential file path for accessing cloud resources. */

--- a/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
@@ -19,19 +19,19 @@ public class TestConfiguration {
   /** How long to keep the resource before the 'prod' Janitor do the cleanup. */
   public static Duration RESOURCE_TIME_TO_LIVE_PROD = Duration.ofMinutes(30);
 
-  /** pubsub project id to publish track resource to Janitor test env(toolsalpha) */
+  /** pubsub project id to publish track resource to Janitor test env(tools) */
   private String resourceProjectId;
 
   /** pubsub project id to publish track resource to Janitor prod env(tools) */
   private String prodTrackResourceProjectId;
 
-  /** pubsub topic id to publish track resource to Janitor test env(toolsalpha) */
+  /** pubsub topic id to publish track resource to Janitor test env(tools) */
   private String trackResourceTopicId;
 
   /** pubsub topic id to publish track resource to Janitor prod env(tools) */
   private String prodTrackResourceTopicId;
 
-  /** Credential file path to be able to publish message to Janitor test env (toolsalpha). */
+  /** Credential file path to be able to publish message to Janitor test env (tools). */
   private String janitorClientServiceAccountPath;
 
   /** Credential file path to be able to publish message to Janitor prod env (tools). */

--- a/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
@@ -19,22 +19,22 @@ public class TestConfiguration {
   /** How long to keep the resource before the 'prod' Janitor do the cleanup. */
   public static Duration RESOURCE_TIME_TO_LIVE_PROD = Duration.ofMinutes(30);
 
-  /** pubsub project id to publish track resource to Janitor test env(tools) */
+  /** pubsub project id to publish track resource to Janitor test env(qa) */
   private String resourceProjectId;
 
-  /** pubsub project id to publish track resource to Janitor prod env(tools) */
+  /** pubsub project id to publish track resource to Janitor prod env(qa) */
   private String prodTrackResourceProjectId;
 
-  /** pubsub topic id to publish track resource to Janitor test env(tools) */
+  /** pubsub topic id to publish track resource to Janitor test env(qa) */
   private String trackResourceTopicId;
 
-  /** pubsub topic id to publish track resource to Janitor prod env(tools) */
+  /** pubsub topic id to publish track resource to Janitor prod env(qa) */
   private String prodTrackResourceTopicId;
 
-  /** Credential file path to be able to publish message to Janitor test env (tools). */
+  /** Credential file path to be able to publish message to Janitor test env (qa). */
   private String janitorClientServiceAccountPath;
 
-  /** Credential file path to be able to publish message to Janitor prod env (tools). */
+  /** Credential file path to be able to publish message to Janitor prod env (qa). */
   private String prodJanitorClientCredentialFilePath;
 
   /** Credential file path for accessing cloud resources. */

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -16,7 +16,7 @@ janitor:
     prod-track-resource-topic-id: crljanitor-tools-pubsub-topic
     resource-credential-file-path: rendered/cloud-access-sa-account.json
     resource-project-id: terra-janitor-test
-    track-resource-topic-id: crljanitor-qa-pubsub-sub
+    track-resource-topic-id: crljanitor-qa-pubsub-topic
     # Reusing static MRG from https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-billing-project-to-landing-zone.yaml
     azure-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
     azure-subscription-id: f557c728-871d-408c-a28b-eb6b2141a087

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -9,7 +9,7 @@ janitor:
       project-id: terra-kernel-k8s
       subscription: crljanitor-tools-pubsub-sub
   test:
-    janitor-client-service-account-path: rendered/client-sa-account.json
+    janitor-client-service-account-path: rendered/tools-client-sa-account.json
     parent-resource-id: folders/1074206284898
     prod-janitor-client-credential-file-path: rendered/tools-client-sa-account.json
     prod-track-resource-project-id: terra-kernel-k8s

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -6,7 +6,7 @@ janitor:
   pubsub:
     track-resource:
       enabled: true
-      project-id: terra-kernel-k8s
+      project-id: broad-dsde-qa
       subscription: crljanitor-qa-pubsub-sub
   test:
     janitor-client-service-account-path: rendered/client-sa-account.json

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -7,7 +7,7 @@ janitor:
     track-resource:
       enabled: true
       project-id: terra-kernel-k8s
-      subscription: crljanitor-toolsalpha-pubsub-sub
+      subscription: crljanitor-tools-pubsub-sub
   test:
     janitor-client-service-account-path: rendered/client-sa-account.json
     parent-resource-id: folders/1074206284898
@@ -16,7 +16,7 @@ janitor:
     prod-track-resource-topic-id: crljanitor-tools-pubsub-topic
     resource-credential-file-path: rendered/cloud-access-sa-account.json
     resource-project-id: terra-janitor-test
-    track-resource-topic-id: crljanitor-toolsalpha-pubsub-topic
+    track-resource-topic-id: crljanitor-tools-pubsub-topic
     # Reusing static MRG from https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-billing-project-to-landing-zone.yaml
     azure-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
     azure-subscription-id: f557c728-871d-408c-a28b-eb6b2141a087

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -7,16 +7,16 @@ janitor:
     track-resource:
       enabled: true
       project-id: terra-kernel-k8s
-      subscription: crljanitor-tools-pubsub-sub
+      subscription: crljanitor-qa-pubsub-sub
   test:
-    janitor-client-service-account-path: rendered/tools-client-sa-account.json
+    janitor-client-service-account-path: rendered/client-sa-account.json
     parent-resource-id: folders/1074206284898
     prod-janitor-client-credential-file-path: rendered/tools-client-sa-account.json
     prod-track-resource-project-id: terra-kernel-k8s
     prod-track-resource-topic-id: crljanitor-tools-pubsub-topic
     resource-credential-file-path: rendered/cloud-access-sa-account.json
     resource-project-id: terra-janitor-test
-    track-resource-topic-id: crljanitor-tools-pubsub-topic
+    track-resource-topic-id: crljanitor-qa-pubsub-sub
     # Reusing static MRG from https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-billing-project-to-landing-zone.yaml
     azure-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
     azure-subscription-id: f557c728-871d-408c-a28b-eb6b2141a087


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-265

The app-sa, client-sa and pubsub queue in the old `toolsalpha` env are now replaced with new ones that were [terraformed](https://github.com/broadinstitute/terraform-ap-deployments/pull/1800) in the `broad-dsde-qa` project. This allows us to re-enable all of the integration tests for GCP resources.