### PR TITLE
CORE-279: Dependabot configuration and auto-approve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    open-pull-requests-limit: 10
+    groups:
+      minor-patch-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
+    target-branch: "master"
+    reviewers:
+      - "@DataBiosphere/broad-core-services"
+    labels:
+      - "dependency"
+      - "gradle"
+    commit-message:
+      prefix: "[CORE-69]"

--- a/.github/workflows/auto-approve-dependabot-prs.yml
+++ b/.github/workflows/auto-approve-dependabot-prs.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-279

* Configuration for scheduling/grouping Dependabot PRs
* Auto-approval for Dependabot PRs

Note that Dependabot is not yet turned on; I want to get these configs in first.