### PR TITLE
CORE-69: update to latest github actions; action cleanup

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -42,7 +42,7 @@ jobs:
           echo semver-part=$SEMVER_PART >> $GITHUB_OUTPUT
           echo checkout-branch=$CHECKOUT_BRANCH >> $GITHUB_OUTPUT
       - name: Checkout current code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.controls.outputs.checkout-branch }}
           token: ${{ secrets.BROADBOT_TOKEN }}
@@ -66,22 +66,22 @@ jobs:
           VERSION_SUFFIX: SNAPSHOT
       - name: Auth to GCR
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
-          version: '411.0.0'
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Explicitly auth Docker for GCR
         if: steps.skiptest.outputs.is-bump == 'no'
         run: gcloud auth configure-docker --quiet
       - name: Set up JDK 17
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Skip version bump merges
         id: skiptest
         uses: ./.github/actions/bump-skip
@@ -91,19 +91,11 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./local-dev/local-postgres-init.sql
       - name: Set up JDK 17
         if: steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Cache Gradle packages
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew


### PR DESCRIPTION
* Use the latest versions of github actions
* Use `setup-java`'s cache for gradle instead of an explicit call to `actions/cache`
* remove an extraneous/unknown input on `google-github-actions/auth`