### PR TITLE
[CORE-265] Remove disabled Azure integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ env:
   JANITOR_CLIENT_SA_FILE: src/test/resources/rendered/client-sa-account.json
   JANITOR_CLIENT_SA_TOOLS_FILE: src/test/resources/rendered/tools-client-sa-account.json
   JANITOR_CLOUD_ACCESS_SA_FILE: src/test/resources/rendered/cloud-access-sa-account.json
-  LOCAL_PROPERTIES_DIRECTORY: config
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -67,22 +66,6 @@ jobs:
           JANITOR_CLOUD_ACCESS_SA=$(echo $JANITOR_CLOUD_ACCESS_SA_B64 | base64 --decode)
           echo ::add-mask::$JANITOR_CLOUD_ACCESS_SA
           echo $JANITOR_CLOUD_ACCESS_SA > $JANITOR_CLOUD_ACCESS_SA_FILE
-          
-          AZURE_PUBLISHER_CLIENT_ID=${{ secrets.AZURE_PUBLISHER_CLIENT_ID }}
-          echo ::add-mask::$AZURE_PUBLISHER_CLIENT_ID
-          AZURE_PUBLISHER_CLIENT_SECRET=${{ secrets.AZURE_PUBLISHER_CLIENT_SECRET }}
-          echo ::add-mask::$AZURE_PUBLISHER_CLIENT_SECRET
-          AZURE_PUBLISHER_TENANT_ID=${{ secrets.AZURE_PUBLISHER_TENANT_ID }}
-          echo ::add-mask::$AZURE_PUBLISHER_TENANT_ID
-          
-          mkdir -p "${LOCAL_PROPERTIES_DIRECTORY}"
-          cat << EOF > ${LOCAL_PROPERTIES_DIRECTORY}/local-properties.yml
-          janitor:
-            azure:
-              managed-app-client-id: ${AZURE_PUBLISHER_CLIENT_ID}
-              managed-app-client-secret: ${AZURE_PUBLISHER_CLIENT_SECRET}
-              managed-app-tenant-id: ${AZURE_PUBLISHER_TENANT_ID}
-          EOF
       - name: Initialize Postgres DB
         if: steps.skiptest.outputs.is-bump == 'no'
         env:

--- a/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
+++ b/src/test/java/bio/terra/janitor/integration/common/configuration/TestConfiguration.java
@@ -4,7 +4,6 @@ import static bio.terra.janitor.common.CredentialUtils.getGoogleCredentialsOrDie
 
 import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.common.cleanup.CleanupConfig;
-import bio.terra.janitor.generated.model.AzureResourceGroup;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -42,33 +41,6 @@ public class TestConfiguration {
 
   /** ID of the parent folder to create projects within. */
   private String parentResourceId;
-
-  /** ID of the Azure tenant to create resources within. */
-  private String azureTenantId;
-
-  /** ID of the Azure subscription to create resources within. */
-  private String azureSubscriptionId;
-
-  /** Name of the Azure managed resource group to create resources within. */
-  private String azureManagedResourceGroupName;
-
-  /** Name of the static Azure storage account. */
-  private String azureStorageAccountName;
-
-  /** Name of the static Azure Relay namespace. */
-  private String azureRelayNamespace;
-
-  /** Name of the status Azure postgres flex server. */
-  private String azurePostgresServerName;
-
-  /** Name of the static Azure vnet. */
-  private String azureVnetName;
-
-  /** Name of the static AKS cluster. */
-  private String aksClusterName;
-
-  /** Name of the static Azure batch account. */
-  private String azureBatchAccountName;
 
   public String getTrackResourceTopicId() {
     return trackResourceTopicId;
@@ -122,78 +94,6 @@ public class TestConfiguration {
     this.parentResourceId = parentResourceId;
   }
 
-  public String getAzureTenantId() {
-    return azureTenantId;
-  }
-
-  public void setAzureTenantId(String azureTenantId) {
-    this.azureTenantId = azureTenantId;
-  }
-
-  public String getAzureSubscriptionId() {
-    return azureSubscriptionId;
-  }
-
-  public void setAzureSubscriptionId(String azureSubscriptionId) {
-    this.azureSubscriptionId = azureSubscriptionId;
-  }
-
-  public String getAzureManagedResourceGroupName() {
-    return azureManagedResourceGroupName;
-  }
-
-  public void setAzureManagedResourceGroupName(String azureManagedResourceGroupName) {
-    this.azureManagedResourceGroupName = azureManagedResourceGroupName;
-  }
-
-  public String getAzureStorageAccountName() {
-    return azureStorageAccountName;
-  }
-
-  public void setAzureStorageAccountName(String azureStorageAccountName) {
-    this.azureStorageAccountName = azureStorageAccountName;
-  }
-
-  public String getAzureRelayNamespace() {
-    return azureRelayNamespace;
-  }
-
-  public void setAzureRelayNamespace(String azureRelayNamespace) {
-    this.azureRelayNamespace = azureRelayNamespace;
-  }
-
-  public String getAzurePostgresServerName() {
-    return azurePostgresServerName;
-  }
-
-  public void setAzurePostgresServerName(String azurePostgresServerName) {
-    this.azurePostgresServerName = azurePostgresServerName;
-  }
-
-  public String getAzureVnetName() {
-    return azureVnetName;
-  }
-
-  public void setAzureVnetName(String azureVnetName) {
-    this.azureVnetName = azureVnetName;
-  }
-
-  public String getAksClusterName() {
-    return aksClusterName;
-  }
-
-  public void setAksClusterName(String aksClusterName) {
-    this.aksClusterName = aksClusterName;
-  }
-
-  public String getAzureBatchAccountName() {
-    return azureBatchAccountName;
-  }
-
-  public void setAzureBatchAccountName(String azureBatchAccountName) {
-    this.azureBatchAccountName = azureBatchAccountName;
-  }
-
   /**
    * Janitor Client {@link ServiceAccountCredentials} which has permission to publish message to
    * Janitor.
@@ -229,10 +129,4 @@ public class TestConfiguration {
     return getGoogleCredentialsOrDie(resourceCredentialFilePath);
   }
 
-  public AzureResourceGroup getAzureResourceGroup() {
-    return new AzureResourceGroup()
-        .tenantId(azureTenantId)
-        .subscriptionId(azureSubscriptionId)
-        .resourceGroupName(azureManagedResourceGroupName);
-  }
 }

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -17,14 +17,3 @@ janitor:
     resource-credential-file-path: rendered/cloud-access-sa-account.json
     resource-project-id: terra-janitor-test
     track-resource-topic-id: crljanitor-qa-pubsub-topic
-    # Reusing static MRG from https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-billing-project-to-landing-zone.yaml
-    azure-tenant-id: fad90753-2022-4456-9b0a-c7e5b934e408
-    azure-subscription-id: f557c728-871d-408c-a28b-eb6b2141a087
-    azure-managed-resource-group-name: e2e-xmx74y
-    azure-storage-account-name: lzf0301a3ce26548178e8ace
-    azure-relay-namespace: lze8caf1818ef66aab01cae5e6cd01bef374ad0c9777d8acbe
-    azure-postgres-server-name: lz435678d1acd5183be2b80d5cb902a805d21891b7bfda7c22377c6e7b04f4a
-    azure-vnet-name: lz7b9e527a5ca64fbc0cb8fa30d73dc47a6b32e147077937cee7db1192e2673a
-    aks-cluster-name: lz188fbab0f65ce4cd
-    azure-batch-account-name: lz1f4f29a3a6389d8dd7db48
-


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/CORE-265

**Background:**
The Azure resources required for the integration tests to run were deleted, causing them to fail. Since we plan on removing support for Azure, delete these disabled integration tests and remove any Azure-specific test configs (since they currently point to non-existent resources).