### PR TITLE
CORE-401: disable otel logback integration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,3 +72,6 @@ otel:
       attributes:
         service:
           name: ${spring.application.name}
+  instrumentation:
+    logback-appender:
+      enabled: false


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-401

This disables the OpenTelemetry Logback integration via a simple config switch. See https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation/ for settings.

The otel/logback integration was not working and would repeatedly log errors:
```
Failed to export logs. The request could not be executed. Full error message: Failed to connect to localhost/127.0.0.1:4318
```

This PR should quell those errors.

Information about the otel/logback integration: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/logback/logback-appender-1.0/library
