### PR TITLE
CORE-391: MockBean -> MockitoBean

### DIFF
--- a/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
+++ b/src/test/java/bio/terra/janitor/integration/TrackResourceIntegrationTest.java
@@ -72,7 +72,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -93,7 +93,8 @@ public class TrackResourceIntegrationTest extends BaseIntegrationTest {
   private CloudResourceManagerCow resourceManagerCow;
   private String projectId;
 
-  @MockBean private WorkspaceManagerService mockWorkspaceManagerService;
+  @MockitoBean
+  private WorkspaceManagerService mockWorkspaceManagerService;
 
   private static final Map<String, String> DEFAULT_LABELS =
       ImmutableMap.of("key1", "value1", "key2", "value2");

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightManagerTest.java
@@ -37,9 +37,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @AutoConfigureMockMvc
@@ -52,7 +52,7 @@ public class FlightManagerTest extends BaseUnitTest {
   @Autowired StairwayComponent stairwayComponent;
   @Autowired JanitorDao janitorDao;
   @Autowired TransactionTemplate transactionTemplate;
-  @MockBean private MetricsHelper mockMetricsHelper;
+  @MockitoBean private MetricsHelper mockMetricsHelper;
 
   private FlightManager createFlightManager(FlightSubmissionFactory submissionFactory) {
     return new FlightManager(

--- a/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
+++ b/src/test/java/bio/terra/janitor/service/cleanup/FlightSchedulerTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @AutoConfigureMockMvc
@@ -40,7 +40,8 @@ public class FlightSchedulerTest extends BaseUnitTest {
   @Autowired JanitorDao janitorDao;
   @Autowired StairwayComponent stairwayComponent;
   @Autowired TransactionTemplate transactionTemplate;
-  @MockBean private MetricsHelper mockMetricsHelper;
+  @MockitoBean
+  private MetricsHelper mockMetricsHelper;
 
   private void initializeScheduler(FlightSubmissionFactory submissionFactory) {
     flightScheduler =

--- a/src/test/java/bio/terra/janitor/service/iam/IamServiceTest.java
+++ b/src/test/java/bio/terra/janitor/service/iam/IamServiceTest.java
@@ -25,7 +25,7 @@ import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @AutoConfigureMockMvc
 public class IamServiceTest extends BaseUnitTest {
@@ -33,7 +33,7 @@ public class IamServiceTest extends BaseUnitTest {
   @Autowired IamService iamService;
   @Autowired IamConfiguration iamConfiguration;
 
-  @MockBean(answer = Answers.RETURNS_DEEP_STUBS)
+  @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
   CrlConfiguration crlConfiguration;
 
   HttpClient mockGcpTokenClient = mock(HttpClient.class, Mockito.RETURNS_DEEP_STUBS);


### PR DESCRIPTION
#196, as part of upgrading terra-common-lib, upgraded Spring Boot.

The newer version of Spring Boot deprecates `@MockBean` in favor of `@MockitoBean` and logs warnings during compilation when `@MockBean` is used.

This PR switches all usages of `@MockBean` to `@MockitoBean`.