### PR TITLE
DDO-4338 publish to gar

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -82,6 +82,12 @@ jobs:
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v2
+      - name: Explicitly auth Docker for GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
+        run: |
+          gcloud auth configure-docker gcr.io --quiet
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+        #run: gcloud auth configure-docker --quiet
       - name: Set up JDK 17
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: actions/setup-java@v4
@@ -99,9 +105,6 @@ jobs:
           GOOGLE_CLOUD_PROJECT: "dsp-artifact-registry"
           GAR_LOCATION: "us-central1"
           GAR_REPOSITORY_ID: "libs-snapshot-standard"
-      - name: Explicitly auth Docker for GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: gcloud auth configure-docker --quiet
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -74,20 +74,9 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
-#      - name: Auth to GCR
-#        if: steps.skiptest.outputs.is-bump == 'no'
-#        uses: google-github-actions/auth@v2
-#        with:
-#          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v2
-      - name: Explicitly auth Docker for GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: |
-          gcloud auth configure-docker gcr.io --quiet
-          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-        #run: gcloud auth configure-docker --quiet
       - name: Set up JDK 17
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: actions/setup-java@v4
@@ -105,6 +94,14 @@ jobs:
           GOOGLE_CLOUD_PROJECT: "dsp-artifact-registry"
           GAR_LOCATION: "us-central1"
           GAR_REPOSITORY_ID: "libs-snapshot-standard"
+      - name: Auth to GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+      - name: Explicitly auth Docker for GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
+        run: gcloud auth configure-docker --quiet
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   tag-build-push:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write'
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       is-bump: ${{ steps.skiptest.outputs.is-bump }}

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -71,6 +71,14 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+      - name: Auth to GCP
+        if: steps.skiptest.outputs.is-bump == 'no'
+        id: 'auth'
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -66,11 +66,6 @@ jobs:
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.janitorVersion\\s*=\\s*'.*'"
           VERSION_SUFFIX: SNAPSHOT
-      - name: Auth to GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Auth to GCP
         if: steps.skiptest.outputs.is-bump == 'no'
         id: 'auth'
@@ -79,6 +74,11 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
+      - name: Auth to GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -74,17 +74,14 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
           service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
-      - name: Auth to GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+#      - name: Auth to GCR
+#        if: steps.skiptest.outputs.is-bump == 'no'
+#        uses: google-github-actions/auth@v2
+#        with:
+#          credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v2
-      - name: Explicitly auth Docker for GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: gcloud auth configure-docker --quiet
       - name: Set up JDK 17
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: actions/setup-java@v4
@@ -102,6 +99,9 @@ jobs:
           GOOGLE_CLOUD_PROJECT: "dsp-artifact-registry"
           GAR_LOCATION: "us-central1"
           GAR_REPOSITORY_ID: "libs-snapshot-standard"
+      - name: Explicitly auth Docker for GCR
+        if: steps.skiptest.outputs.is-bump == 'no'
+        run: gcloud auth configure-docker --quiet
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -2,7 +2,7 @@ name: Tag, Build, and Push Image
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, un-ddo-4338 ]
     paths-ignore: [ '**.md' ]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -85,13 +85,13 @@ jobs:
       - name: Grant execute permission for gradlew
         if: steps.skiptest.outputs.is-bump == 'no'
         run: chmod +x gradlew
-      - name: "Publish client to Artifactory"
+      - name: Publish client to Google Artifact Registry
         if: steps.skiptest.outputs.is-bump == 'no'
-        run: ./gradlew artifactoryPublish
+        run: ./gradlew publish
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
+          GOOGLE_CLOUD_PROJECT: "dsp-artifact-registry"
+          GAR_LOCATION: "us-central1"
+          GAR_REPOSITORY_ID: "libs-snapshot-standard"
       - name: Build and push GCR image using Jib
         if: steps.skiptest.outputs.is-bump == 'no'
         run: "./gradlew jib --image=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -2,7 +2,7 @@ name: Tag, Build, and Push Image
 
 on:
   push:
-    branches: [ master, un-ddo-4338 ]
+    branches: [ master ]
     paths-ignore: [ '**.md' ]
   workflow_dispatch:
     inputs:

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -30,20 +30,3 @@ publishing {
     }
 
 }
-
-//// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-//artifactory {
-//    publish {
-//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-//        repository {
-//            repoKey = "${artifactory_repo_key}"
-//            username = "${artifactory_username}"
-//            password = "${artifactory_password}"
-//        }
-//        defaults {
-//            publications('janitorClientLibrary')
-//            publishArtifacts = true
-//            publishPom = true
-//        }
-//    }
-//}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,13 +1,14 @@
-def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-snapshot-local'
-def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+def garLocation = System.getenv("GAR_LOCATION")
+def garRepoId = System.getenv("GAR_REPOSITORY_ID")
 
 gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.hasTask(artifactoryPublish) &&
-            (artifactory_username == null || artifactory_password == null)) {
-        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
+    if (taskGraph.hasTask(publish) &&
+            (garProjectId == null || garLocation == null || garRepoId == null)) {
+        throw new GradleException("Set env vars GOOGLE_CLOUD_PROJECT, GAR_LOCATION, and GAR_REPOSITORY_ID to publish")
     }
 }
+
 
 // Publish jar file to a Maven module/artifact using the maven-publish plugin.
 publishing {
@@ -21,21 +22,28 @@ publishing {
             }
         }
     }
-}
 
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-artifactory {
-    publish {
-        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-        repository {
-            repoKey = "${artifactory_repo_key}"
-            username = "${artifactory_username}"
-            password = "${artifactory_password}"
-        }
-        defaults {
-            publications('janitorClientLibrary')
-            publishArtifacts = true
-            publishPom = true
+    repositories {
+        maven {
+            url = uri("artifactregistry://${garLocation}-maven.pkg.dev/${garProjectId}/${garRepoId}")
         }
     }
+
 }
+
+//// Upload Maven artifacts to Artifactory using the Artifactory plugin.
+//artifactory {
+//    publish {
+//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
+//        repository {
+//            repoKey = "${artifactory_repo_key}"
+//            username = "${artifactory_username}"
+//            password = "${artifactory_password}"
+//        }
+//        defaults {
+//            publications('janitorClientLibrary')
+//            publishArtifacts = true
+//            publishPom = true
+//        }
+//    }
+//}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,12 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
+    }
+}
+
 rootProject.name = 'terra-resource-janitor'
 include 'terra-resource-janitor-client'
 

--- a/terra-resource-janitor-client/build.gradle
+++ b/terra-resource-janitor-client/build.gradle
@@ -2,17 +2,16 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 
-    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5' //apply false
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5' apply false
     id 'org.hidetake.swagger.generator' version '2.19.2'
 }
 
-////todo: test again
-//// Only apply the Artifact Registry plugin if a publish task is being run. This avoids requiring gcloud to be
-//// installed and authenticated in CI jobs that don't publish (e.g., linter, tests, static analysis).
-//def isPublishing = gradle.startParameter.taskNames.any { it.toLowerCase().contains('publish') }
-//if (isPublishing) {
-//    apply plugin: 'com.google.cloud.artifactregistry.gradle-plugin'
-//}
+// Only apply the Artifact Registry plugin if a publish task is being run. This avoids requiring gcloud to be
+// installed and authenticated in CI jobs that don't publish (e.g., linter, tests, static analysis).
+def isPublishing = gradle.startParameter.taskNames.any { it.toLowerCase().contains('publish') }
+if (isPublishing) {
+    apply plugin: 'com.google.cloud.artifactregistry.gradle-plugin'
+}
 
 repositories {
     mavenCentral()

--- a/terra-resource-janitor-client/build.gradle
+++ b/terra-resource-janitor-client/build.gradle
@@ -2,9 +2,17 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 
-    id 'com.jfrog.artifactory' version '4.29.0'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5' //apply false
     id 'org.hidetake.swagger.generator' version '2.19.2'
 }
+
+////todo: test again
+//// Only apply the Artifact Registry plugin if a publish task is being run. This avoids requiring gcloud to be
+//// installed and authenticated in CI jobs that don't publish (e.g., linter, tests, static analysis).
+//def isPublishing = gradle.startParameter.taskNames.any { it.toLowerCase().contains('publish') }
+//if (isPublishing) {
+//    apply plugin: 'com.google.cloud.artifactregistry.gradle-plugin'
+//}
 
 repositories {
     mavenCentral()

--- a/terra-resource-janitor-client/publish.sh
+++ b/terra-resource-janitor-client/publish.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
 # Publish Janitor Client Package:
-VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
-DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
-ARTIFACTORY_ACCOUNT_PATH=secret/dsp/accts/artifactory/dsdejenkins
 
-export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
- vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
-export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
- vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
-../gradlew test artifactoryPublish
+../gradlew test publish


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DDO-4338

Migrate artifact publishing from JFrog to Google Artifact Registry.



Note:

> The two failing tests (`subscribeAndCleanupResource_googleNotebookInstance` and `subscribeAndCleanupResource_alreadyDeletedGoogleNotebookInstance`) are failing because Vertex AI Workbench user-managed notebooks have been deprecated.
> 
> The recommended approach is to migrate these tests to use Vertex AI Workbench managed notebooks. See the [migration guide](https://cloud.google.com/vertex-ai/docs/workbench/user-managed/migrate-to-instances) for details.
> 
> To unblock the GAR migration work (which is unrelated to the test failure), I've created [DDO-4341](https://broadworkbench.atlassian.net/browse/DDO-4341) to address the issue at a later time.
> 
> [DDO-4341]: https://broadworkbench.atlassian.net/browse/DDO-4341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ